### PR TITLE
Add entry point

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -178,3 +178,6 @@ def refresh_completions(pgexecute, completer):
     for table in tables:
         completer.extend_column_names(table, pgexecute.columns(table))
     completer.extend_database_names(pgexecute.databases())
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
I'm a distro packager and the generated /usr/bin/pgcli doesn't work for me and I need more control. I need my own entry point so I can execute the module using python -m pgcli.main.