### PR TITLE
Fix \d [pattern] to not fail with (global name 'true' is not defined)

### DIFF
--- a/pgcli/packages/pgspecial.py
+++ b/pgcli/packages/pgspecial.py
@@ -557,7 +557,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
                         elif category == 3:
                             status.append("Triggers firing on replica only:")
                         status.append('\n')
-                        have_heading = true;
+                        have_heading = True
 
                     #/* Everything after "TRIGGER" is echoed verbatim */
                     tgdef = row[1]


### PR DESCRIPTION
Running `\d table_name` would always fail with the error `global name 'true' is not defined`.