### PR TITLE
Pin down minimum psycopg2 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         install_requires=[
             'Click',
             'prompt_toolkit',
-            'psycopg2',
+            'psycopg2 >= 2.5.4',
             'sqlparse',
             ],
         entry_points='''


### PR DESCRIPTION
It seems like some of the issues (see #38, #26) in the tracker are caused by people having older versions of psycopg2 installed. This pull request aims to fix that.

Note that it might also be good to pin down other requirements, especially for prompt_toolkit!

