### PR TITLE
Add expanded output (\x) support

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -18,8 +18,9 @@ from pygments.lexers.sql import SqlLexer
 from psycopg2 import Error
 
 from .packages.tabulate import tabulate
+from .packages.expanded import expanded_table
 from .packages.pgspecial import (CASE_SENSITIVE_COMMANDS,
-        NON_CASE_SENSITIVE_COMMANDS)
+        NON_CASE_SENSITIVE_COMMANDS, is_expanded_output)
 from .pgcompleter import PGCompleter
 from .pgtoolbar import PGToolbar
 from .pgstyle import PGStyle
@@ -29,47 +30,6 @@ from .config import write_default_config, load_config
 from .key_bindings import pgcli_bindings
 
 _logger = logging.getLogger(__name__)
-
-def pad(field, total, char=u" "):
-    return field + (char * (total - len(field)))
-
-def get_separator(num, header_len, data_len):
-    total_len = header_len + data_len + 1
-
-    sep = u"-[ RECORD {0} ]".format(unicode(num))
-    if len(sep) < header_len:
-        sep = pad(sep, header_len - 1, u"-") + u"+"
-
-    if len(sep) < total_len:
-        sep = pad(sep, total_len, u"-")
-
-    return sep + u"\n"
-
-def expanded_table(rows, headers):
-    header_len = max([len(x) for x in headers])
-    max_row_len = 0
-    results = []
-
-    padded_headers = [pad(x, header_len) + u" |" for x in headers]
-    header_len += 2
-
-    for row in rows:
-        row_len = max([len(str(x)) for x in row])
-        row_result = ""
-        if row_len > max_row_len:
-            max_row_len = row_len
-
-        for item in zip(padded_headers, row):
-            row_result += item[0] + u" " + unicode(item[1]) + u"\n"
-
-        results.append(row_result)
-
-    output = ""
-    for i, result in enumerate(results):
-        output += get_separator(i, header_len, max_row_len)
-        output += result
-
-    return output
 
 @click.command()
 @click.option('-h', '--host', default='', help='Host address of the '
@@ -150,8 +110,10 @@ def cli(database, user, password, host, port):
                     _logger.debug("headers: %r", headers)
                     _logger.debug("rows: %r", rows)
                     if rows:
-                        # output.append(tabulate(rows, headers, tablefmt='fancy_grid'))
-                        output.append(expanded_table(rows, headers))
+                        if is_expanded_output():
+                            output.append(expanded_table(rows, headers))
+                        else:
+                            output.append(tabulate(rows, headers, tablefmt='psql'))
                     if status:  # Only print the status if it's not None.
                         output.append(status)
                     _logger.debug("status: %r", status)

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -30,6 +30,47 @@ from .key_bindings import pgcli_bindings
 
 _logger = logging.getLogger(__name__)
 
+def pad(field, total, char=u" "):
+    return field + (char * (total - len(field)))
+
+def get_separator(num, header_len, data_len):
+    total_len = header_len + data_len + 1
+
+    sep = u"-[ RECORD {0} ]".format(unicode(num))
+    if len(sep) < header_len:
+        sep = pad(sep, header_len - 1, u"-") + u"+"
+
+    if len(sep) < total_len:
+        sep = pad(sep, total_len, u"-")
+
+    return sep + u"\n"
+
+def expanded_table(rows, headers):
+    header_len = max([len(x) for x in headers])
+    max_row_len = 0
+    results = []
+
+    padded_headers = [pad(x, header_len) + u" |" for x in headers]
+    header_len += 2
+
+    for row in rows:
+        row_len = max([len(str(x)) for x in row])
+        row_result = ""
+        if row_len > max_row_len:
+            max_row_len = row_len
+
+        for item in zip(padded_headers, row):
+            row_result += item[0] + u" " + unicode(item[1]) + u"\n"
+
+        results.append(row_result)
+
+    output = ""
+    for i, result in enumerate(results):
+        output += get_separator(i, header_len, max_row_len)
+        output += result
+
+    return output
+
 @click.command()
 @click.option('-h', '--host', default='', help='Host address of the '
         'postgres database.')
@@ -109,7 +150,8 @@ def cli(database, user, password, host, port):
                     _logger.debug("headers: %r", headers)
                     _logger.debug("rows: %r", rows)
                     if rows:
-                        output.append(tabulate(rows, headers, tablefmt='psql'))
+                        # output.append(tabulate(rows, headers, tablefmt='fancy_grid'))
+                        output.append(expanded_table(rows, headers))
                     if status:  # Only print the status if it's not None.
                         output.append(status)
                     _logger.debug("status: %r", status)

--- a/pgcli/packages/expanded.py
+++ b/pgcli/packages/expanded.py
@@ -1,0 +1,41 @@
+def pad(field, total, char=u" "):
+    return field + (char * (total - len(field)))
+
+def get_separator(num, header_len, data_len):
+    total_len = header_len + data_len + 1
+
+    sep = u"-[ RECORD {0} ]".format(unicode(num))
+    if len(sep) < header_len:
+        sep = pad(sep, header_len - 1, u"-") + u"+"
+
+    if len(sep) < total_len:
+        sep = pad(sep, total_len, u"-")
+
+    return sep + u"\n"
+
+def expanded_table(rows, headers):
+    header_len = max([len(x) for x in headers])
+    max_row_len = 0
+    results = []
+
+    padded_headers = [pad(x, header_len) + u" |" for x in headers]
+    header_len += 2
+
+    for row in rows:
+        row_len = max([len(str(x)) for x in row])
+        row_result = ""
+        if row_len > max_row_len:
+            max_row_len = row_len
+
+        for item in zip(padded_headers, row):
+            row_result += item[0] + u" " + unicode(item[1]) + u"\n"
+
+        results.append(row_result)
+
+    output = ""
+    for i, result in enumerate(results):
+        output += get_separator(i, header_len, max_row_len)
+        output += result
+
+    return output
+

--- a/pgcli/packages/pgspecial.py
+++ b/pgcli/packages/pgspecial.py
@@ -19,6 +19,9 @@ class MockLogging(object):
         print ()
 
 #log = MockLogging()
+use_expanded_output = False
+def is_expanded_output():
+    return use_expanded_output
 
 def parse_special_command(sql):
     command, _, arg = sql.partition(' ')
@@ -687,7 +690,11 @@ def change_db(cur, arg, verbose):
     raise NotImplementedError
 
 def expanded_output(cur, arg, verbose):
-    import ipdb; ipdb.set_trace()
+    global use_expanded_output
+    use_expanded_output = not use_expanded_output
+    message = u"Expanded display is "
+    message += u"on" if use_expanded_output else u"off"
+    return [(None, None, message + u".")]
 
 CASE_SENSITIVE_COMMANDS = {
             '\?': (show_help, ['\?', 'Help on pgcli commands.']),

--- a/pgcli/packages/pgspecial.py
+++ b/pgcli/packages/pgspecial.py
@@ -686,12 +686,15 @@ def show_help(cur, arg, verbose):  # All the parameters are ignored.
 def change_db(cur, arg, verbose):
     raise NotImplementedError
 
+def expanded_output(cur, arg, verbose):
+    import ipdb; ipdb.set_trace()
 
 CASE_SENSITIVE_COMMANDS = {
             '\?': (show_help, ['\?', 'Help on pgcli commands.']),
             '\c': (change_db, ['\c database_name', 'Connect to a new database.']),
             '\l': ('''SELECT datname FROM pg_database;''', ['\l', 'list databases.']),
             '\d': (describe_table_details, ['\d [pattern]', 'list or describe tables, views and sequences.']),
+            '\\x': (expanded_output, ['x', "hello"]),
             '\dt': ('''SELECT n.nspname as "Schema", c.relname as "Name", CASE
             c.relkind WHEN 'r' THEN 'table' WHEN 'v' THEN 'view' WHEN 'm' THEN
             'materialized view' WHEN 'i' THEN 'index' WHEN 'S' THEN 'sequence'

--- a/pgcli/packages/pgspecial.py
+++ b/pgcli/packages/pgspecial.py
@@ -701,7 +701,7 @@ CASE_SENSITIVE_COMMANDS = {
             '\c': (change_db, ['\c database_name', 'Connect to a new database.']),
             '\l': ('''SELECT datname FROM pg_database;''', ['\l', 'list databases.']),
             '\d': (describe_table_details, ['\d [pattern]', 'list or describe tables, views and sequences.']),
-            '\\x': (expanded_output, ['x', "hello"]),
+            '\\x': (expanded_output, ['\\x', 'Toggle expanded output.']),
             '\dt': ('''SELECT n.nspname as "Schema", c.relname as "Name", CASE
             c.relkind WHEN 'r' THEN 'table' WHEN 'v' THEN 'view' WHEN 'm' THEN
             'materialized view' WHEN 'i' THEN 'index' WHEN 'S' THEN 'sequence'

--- a/tests/test_expanded.py
+++ b/tests/test_expanded.py
@@ -1,0 +1,14 @@
+from pgcli.packages.expanded import expanded_table
+import pytest
+
+def test_expanded_table_renders():
+    input = [("hello", 123),("world", 456)]
+
+    expected = """-[ RECORD 0 ]
+name | hello
+age  | 123
+-[ RECORD 1 ]
+name | world
+age  | 456
+"""
+    assert expected == expanded_table(input, ["name", "age"])


### PR DESCRIPTION
Hi @amjith
I've added an expanded output flag, it attempts to emulate the psql version as much as possible.
Unfortunately I couldn't find a nice way of doing this with tabulate so added my own `expanded.py`.
Let me know if anything needs modified!

Thanks