### PR TITLE
Travis - run tox only once per python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
-python:
-  - "3.4"
-  - "3.3"
-  - "2.7"
-  - "2.6"
+env:
+  - TOX_ENV=py26
+  - TOX_ENV=py27
+  - TOX_ENV=py33
+  - TOX_ENV=py34
 
 install: pip install tox
 
-script: tox
+script: tox -e $TOX_ENV

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -1,6 +1,0 @@
-[tox]
-envlist = py26, py27, py33, py34
-
-[testenv]
-deps = pytest
-commands = py.test 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33
+envlist = py26, py27, py33, py34
 [testenv]
 deps = pytest
     mock


### PR DESCRIPTION
Current version of pgcli runs tests too many times in travis, total 12 times instead of 4.

Example: https://travis-ci.org/amjith/pgcli/builds/46215230
Idea for the solution was taken from https://github.com/eventlet/eventlet/blob/master/.travis.yml