### PR TITLE
Faster startup

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -181,10 +181,10 @@ def quit_command(sql):
             or sql.strip() == ':q')
 
 def refresh_completions(pgexecute, completer):
-    tables = pgexecute.tables()
+    tables, columns = pgexecute.tables()
     completer.extend_table_names(tables)
     for table in tables:
-        completer.extend_column_names(table, pgexecute.columns(table))
+        completer.extend_column_names(table, columns[table])
     completer.extend_database_names(pgexecute.databases())
 
 if __name__ == "__main__":

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -103,15 +103,13 @@ def cli(database, user, password, host, port):
             try:
                 _logger.debug('sql: %r', document.text)
                 res = pgexecute.run(document.text)
+
                 output = []
                 for rows, headers, status in res:
                     _logger.debug("headers: %r", headers)
                     _logger.debug("rows: %r", rows)
-                    if rows:
-                        output.append(tabulate(rows, headers, tablefmt='psql'))
-                    if status:  # Only print the status if it's not None.
-                        output.append(status)
                     _logger.debug("status: %r", status)
+                    output.extend(format_output(rows, headers, status))
                 click.echo_via_pager('\n'.join(output))
             except Exception as e:
                 _logger.error("sql: %r, error: %r", document.text, e)
@@ -127,6 +125,14 @@ def cli(database, user, password, host, port):
     finally:  # Reset the less opts back to original.
         _logger.debug('Restoring env var LESS to %r.', original_less_opts)
         os.environ['LESS'] = original_less_opts
+
+def format_output(rows, headers, status):
+    output = []
+    if rows:
+        output.append(tabulate(rows, headers, tablefmt='psql'))
+    if status:  # Only print the status if it's not None.
+        output.append(status)
+    return '\n'.join(output)
 
 def need_completion_refresh(sql):
     try:

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -132,7 +132,7 @@ def format_output(rows, headers, status):
         output.append(tabulate(rows, headers, tablefmt='psql'))
     if status:  # Only print the status if it's not None.
         output.append(status)
-    return '\n'.join(output)
+    return output
 
 def need_completion_refresh(sql):
     try:

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -65,7 +65,7 @@ class PGExecute(object):
     FROM pg_catalog.pg_database d
     ORDER BY 1;"""
 
-    def __init__(self, database, user, password, host, port):
+    def __init__(self, database=None, user=None, password=None, host=None, port=None):
         (self.dbname, self.user, self.password, self.host, self.port) = \
                 _parse_dsn(database, default_user=user,
                         default_password=password, default_host=host,

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -65,7 +65,7 @@ class PGExecute(object):
     FROM pg_catalog.pg_database d
     ORDER BY 1;"""
 
-    def __init__(self, database=None, user=None, password=None, host=None, port=None):
+    def __init__(self, database, user, password, host, port):
         (self.dbname, self.user, self.password, self.host, self.port) = \
                 _parse_dsn(database, default_user=user,
                         default_password=password, default_host=host,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+from utils import *
+from pgcli.pgexecute import PGExecute
+
+
+@pytest.yield_fixture(scope="function")
+def connection():
+    create_db('_test_db')
+    connection = db_connection('_test_db')
+    yield connection
+
+    drop_tables(connection)
+    connection.close()
+
+
+@pytest.fixture
+def cursor(connection):
+    with connection.cursor() as cur:
+        return cur
+
+
+@pytest.fixture
+def executor(connection):
+    return PGExecute(database='_test_db', user=POSTGRES_USER, host=POSTGRES_HOST)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,4 +21,5 @@ def cursor(connection):
 
 @pytest.fixture
 def executor(connection):
-    return PGExecute(database='_test_db', user=POSTGRES_USER, host=POSTGRES_HOST)
+    return PGExecute(database='_test_db', user=POSTGRES_USER, host=POSTGRES_HOST,
+        password=None, port=None)

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -1,4 +1,5 @@
 from pgcli.pgexecute import _parse_dsn
+from utils import *
 
 def test__parse_dsn():
     test_cases = [
@@ -32,9 +33,13 @@ def test__parse_dsn():
 
             # Full dsn with all components but with postgresql:// prefix.
             ('postgresql://user:password@host:5432/dbname',
-                ('dbname', 'user', 'password', 'host', '5432')),
-
+                ('dbname', 'user', 'password', 'host', '5432'))
             ]
 
     for dsn, expected in test_cases:
         assert _parse_dsn(dsn, 'fuser', 'fpasswd', 'fhost', '1234') == expected
+
+@dbtest
+def test_conn(cursor, executor):
+    data = executor.run('''create table test(id integer)''')
+    assert not data

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -51,3 +51,18 @@ def test_conn(executor):
         | abc |
         +-----+
         SELECT 1""")
+
+@dbtest
+def test_table_and_columns_query(executor):
+    run(executor, "create table a(x text, y text)")
+    run(executor, "create table b(z text)")
+
+    tables, columns = executor.tables()
+    assert tables == ['a', 'b']
+    assert columns['a'] == ['x', 'y']
+    assert columns['b'] == ['z']
+
+@dbtest
+def test_database_list(executor):
+    databases = executor.databases()
+    assert '_test_db' in databases

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -1,4 +1,5 @@
 from pgcli.pgexecute import _parse_dsn
+from textwrap import dedent
 from utils import *
 
 def test__parse_dsn():
@@ -40,6 +41,13 @@ def test__parse_dsn():
         assert _parse_dsn(dsn, 'fuser', 'fpasswd', 'fhost', '1234') == expected
 
 @dbtest
-def test_conn(cursor, executor):
-    data = executor.run('''create table test(id integer)''')
-    assert not data
+def test_conn(executor):
+    run(executor, '''create table test(a text)''')
+    run(executor, '''insert into test values('abc')''')
+    assert run(executor, '''select * from test''') == dedent("""\
+        +-----+
+        | a   |
+        |-----|
+        | abc |
+        +-----+
+        SELECT 1""")

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -34,7 +34,7 @@ def test__parse_dsn():
 
             # Full dsn with all components but with postgresql:// prefix.
             ('postgresql://user:password@host:5432/dbname',
-                ('dbname', 'user', 'password', 'host', '5432'))
+                ('dbname', 'user', 'password', 'host', '5432')),
             ]
 
     for dsn, expected in test_cases:
@@ -44,7 +44,7 @@ def test__parse_dsn():
 def test_conn(executor):
     run(executor, '''create table test(a text)''')
     run(executor, '''insert into test values('abc')''')
-    assert run(executor, '''select * from test''') == dedent("""\
+    assert run(executor, '''select * from test''', join=True) == dedent("""\
         +-----+
         | a   |
         |-----|

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,8 +35,11 @@ def drop_tables(conn):
         cur.execute('''DROP SCHEMA public CASCADE; CREATE SCHEMA public''')
 
 
-def run(executor, sql):
+def run(executor, sql, join=False):
     " Return string output for the sql to be run "
-    data = executor.run(sql)
-    assert len(data) == 1 # current code does that
-    return format_output(*data[0])
+    result = []
+    for rows, headers, status in executor.run(sql):
+        result.extend(format_output(rows, headers, status))
+    if join:
+        result = '\n'.join(result)
+    return result

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,34 @@
+import pytest
+import psycopg2
+
+# TODO: should this be somehow be divined from environment?
+POSTGRES_USER, POSTGRES_HOST = 'postgres', 'localhost'
+
+
+def db_connection(dbname=None):
+    conn = psycopg2.connect(user=POSTGRES_USER, host=POSTGRES_HOST, dbname=dbname)
+    conn.autocommit = True
+    return conn
+
+try:
+    db_connection()
+    CAN_CONNECT_TO_DB = True
+except:
+    CAN_CONNECT_TO_DB = False
+
+dbtest = pytest.mark.skipif(
+    not CAN_CONNECT_TO_DB,
+    reason="Need a postgres instance at localhost accessible by user 'postgres'")
+
+
+def create_db(dbname):
+    with db_connection().cursor() as cur:
+        try:
+            cur.execute('''CREATE DATABASE _test_db''')
+        except:
+            pass
+
+
+def drop_tables(conn):
+    with conn.cursor() as cur:
+        cur.execute('''DROP SCHEMA public CASCADE; CREATE SCHEMA public''')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import pytest
 import psycopg2
+from pgcli.main import format_output
 
 # TODO: should this be somehow be divined from environment?
 POSTGRES_USER, POSTGRES_HOST = 'postgres', 'localhost'
@@ -32,3 +33,10 @@ def create_db(dbname):
 def drop_tables(conn):
     with conn.cursor() as cur:
         cur.execute('''DROP SCHEMA public CASCADE; CREATE SCHEMA public''')
+
+
+def run(executor, sql):
+    " Return string output for the sql to be run "
+    data = executor.run(sql)
+    assert len(data) == 1 # current code does that
+    return format_output(*data[0])

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@ envlist = py26, py27, py33, py34
 [testenv]
 deps = pytest
     mock
-commands = py.test
+commands = py.test --capture=sys --showlocals


### PR DESCRIPTION
Do only one query for all columns, instead of len(tables) queries. Should fix #25.

Note that as I wanted to have tests, you should probably merge in #75 first. For an accurate diff, see the last commit!