### PR TITLE
support for table/column names which should be escaped

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -131,7 +131,7 @@ def cli(database, user, password, host, port):
 def need_completion_refresh(sql):
     try:
         first_token = sql.split()[0]
-        return first_token in ('alter', 'create', 'use', '\c', 'drop')
+        return first_token.lower() in ('alter', 'create', 'use', '\c', 'drop')
     except Exception:
         return False
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -178,6 +178,7 @@ def refresh_completions(pgexecute, completer):
     tables = pgexecute.tables()
     completer.extend_table_names(tables)
     for table in tables:
+        table = table[1:-1] if table[0] == '"' and table[-1] == '"' else table
         completer.extend_column_names(table, pgexecute.columns(table))
     completer.extend_database_names(pgexecute.databases())
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -15,7 +15,6 @@ from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_bindings.emacs import emacs_bindings
 from pygments.lexers.sql import SqlLexer
-from psycopg2 import Error
 
 from .packages.tabulate import tabulate
 from .packages.pgspecial import (CASE_SENSITIVE_COMMANDS,
@@ -114,9 +113,6 @@ def cli(database, user, password, host, port):
                         output.append(status)
                     _logger.debug("status: %r", status)
                     click.echo_via_pager('\n'.join(output))
-            except Error as e:
-                _logger.debug("sql: %r, error: %r", document.text, e.pgerror)
-                click.secho(e.pgerror, err=True, fg='red')
             except Exception as e:
                 _logger.error("sql: %r, error: %r", document.text, e)
                 _logger.error("traceback: %r", traceback.format_exc())

--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -114,8 +114,12 @@ def extract_table_identifiers(token_stream):
                     yield (real_name, identifier.get_alias() or real_name)
         elif isinstance(item, Identifier):
             real_name = item.get_real_name()
+
             if real_name:
                 yield (real_name, item.get_alias() or real_name)
+            else:
+                name = item.get_name()
+                yield (name, item.get_alias() or name)
         elif isinstance(item, Function):
             yield (item.get_name(), item.get_name())
 

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -72,7 +72,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text):
         return 'columns', extract_tables(full_text)
     elif token_v.lower() in ('select', 'where', 'having'):
         return 'columns-and-functions', extract_tables(full_text)
-    elif token_v.lower() in ('from', 'update', 'into', 'describe', 'join', 'alter table'):
+    elif token_v.lower() in ('from', 'update', 'into', 'describe', 'join', 'table'):
         return 'tables', []
     elif token_v in ('d',):  # \d
         return 'tables', []

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -72,7 +72,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text):
         return 'columns', extract_tables(full_text)
     elif token_v.lower() in ('select', 'where', 'having'):
         return 'columns-and-functions', extract_tables(full_text)
-    elif token_v.lower() in ('from', 'update', 'into', 'describe', 'join'):
+    elif token_v.lower() in ('from', 'update', 'into', 'describe', 'join', 'alter table'):
         return 'tables', []
     elif token_v in ('d',):  # \d
         return 'tables', []

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -61,10 +61,7 @@ class PGCompleter(Completer):
         return name
 
     def extend_escaped_names(self, names):
-        for i, name in enumerate(names):
-            names[i] = self.extend_escape_name(name)
-
-        return names
+        return [self.extend_escape_name(name) for name in names]
 
     def extend_special_commands(self, special_commands):
         # Special commands are not part of all_completions since they can only

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -46,7 +46,7 @@ class PGCompleter(Completer):
         super(self.__class__, self).__init__()
         self.smart_completion = smart_completion
 
-        self.name_pattern = compile("^[_a-zA-Z][_a-zA-Z0-9\$]*$")
+        self.name_pattern = compile("^[_a-z][_a-z0-9\$]*$")
 
     def extend_escape_name(self, name):
         if not self.name_pattern.match(name) or name in self.keywords or name in self.functions:


### PR DESCRIPTION
this patch supports table and column names that have space, special chars, non-ascii word characters and names that conflict with build in function names and keywords.

It also fixes a minor issue where the table columns where not refreshed because of a case-sensitive comparison of the tokens.

For example the following tables/columns can be autocompleted with this patch:
```sql
CREATE TABLE "CamelCase" (
  "has space" text,
  "has %^$&" text,
  "φρόνησις" text,
  "MIN" text,
  "DROP" text,
  "CamelCase" text
);
CREATE TABLE "foo bar" (
  "has space" text,
  "has %^$&" text,
  "φρόνησις" text,
  "MIN" text,
  "DROP" text,
  "CamelCase" text
);
CREATE TABLE "foo *@#^!$" (
  "has space" text,
  "has %^$&" text,
  "φρόνησις" text,
  "MIN" text,
  "DROP" text,
  "CamelCase" text
);
CREATE TABLE "εὐδαιμονία" (
  "has space" text,
  "has %^$&" text,
  "φρόνησις" text,
  "MIN" text,
  "DROP" text
);
CREATE TABLE "MIN" (
  "has space" text,
  "has %^$&" text,
  "φρόνησις" text,
  "MIN" text,
  "DROP" text,
  "CamelCase" text
);
```