### PR TITLE
Fix a crash in autocompletion

### DIFF
--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -80,10 +80,11 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text):
         return 'databases', []
     elif token_v.endswith(','):
         prev_keyword = find_prev_keyword(text_before_cursor)
-        return suggest_based_on_last_token(prev_keyword, text_before_cursor, full_text)
+        if prev_keyword:
+            return suggest_based_on_last_token(prev_keyword, text_before_cursor, full_text)
     elif token_v.endswith('.'):
         current_alias = last_word(token_v[:-1])
         tables = extract_tables(full_text, include_alias=True)
         return 'columns', [tables.get(current_alias) or current_alias]
-    else:
-        return 'keywords', []
+
+    return 'keywords', []


### PR DESCRIPTION
This commit fixes a crash in autocompletion, when a comma character is entered before any valid sql keyword, e.g., 
```
database_name> asd,Exception in thread Thread-309:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 552, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 505, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/local/lib/python2.7/dist-packages/prompt_toolkit/__init__.py", line 466, in run
    CompleteEvent(text_inserted=True)))
  File "/usr/local/lib/python2.7/dist-packages/pgcli/pgcompleter.py", line 92, in get_completions
    document.text_before_cursor)
  File "/usr/local/lib/python2.7/dist-packages/pgcli/packages/sqlcompletion.py", line 46, in suggest_type
    return suggest_based_on_last_token(last_token, text_before_cursor, full_text)                                                                              
  File "/usr/local/lib/python2.7/dist-packages/pgcli/packages/sqlcompletion.py", line 83, in suggest_based_on_last_token
    return suggest_based_on_last_token(prev_keyword, text_before_cursor, full_text)
  File "/usr/local/lib/python2.7/dist-packages/pgcli/packages/sqlcompletion.py", line 61, in suggest_based_on_last_token
    token_v = token.value
AttributeError: 'NoneType' object has no attribute 'value'

```

**Note for future refence:** Whenever `find_prev_keyword()` is used, a check should be made in case `None` was returned.