### PR TITLE
ipython magic for faster exploratory data analysis

### DIFF
--- a/pgcli/magic.py
+++ b/pgcli/magic.py
@@ -1,0 +1,34 @@
+from pgcli.main import PGCli
+
+def load_ipython_extension(ipython):
+
+    #This is called via the ipython command '%load_ext pgcli.magic'
+
+    #first, load the sql magic if it isn't already loaded
+    if not ipython.find_line_magic('sql'):
+        ipython.run_line_magic('load_ext', 'sql')
+
+    #register our own magic
+    ipython.register_magic_function(pgcli_line_magic, 'line','pgcli')
+
+def pgcli_line_magic(line):
+
+    #for now, assume line is connection string e.g. postgres://localhost
+    uri = line
+
+    pgcli = PGCli()
+    pgcli.connect_uri(uri)
+
+    try:
+        pgcli.run_cli()
+    except SystemExit:
+        pass
+
+    if not pgcli.query_history:
+        return
+
+    q = pgcli.query_history[-1]
+    if q.successful:
+        ipython = get_ipython()
+        return ipython.run_cell_magic('sql', uri, q.query)
+

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -34,7 +34,175 @@ except ImportError:
 from getpass import getuser
 from psycopg2 import OperationalError
 
-_logger = logging.getLogger(__name__)
+
+class PGCli(object):
+    def __init__(self, force_passwd_prompt=False, never_passwd_prompt=False,
+                 pgexecute=None):
+
+        self.force_passwd_prompt = force_passwd_prompt
+        self.never_passwd_prompt = never_passwd_prompt
+        self.pgexecute = pgexecute
+
+        from pgcli import __file__ as package_root
+        package_root = os.path.dirname(package_root)
+
+        default_config = os.path.join(package_root, 'pgclirc')
+        write_default_config(default_config, '~/.pgclirc')
+
+        # Load config.
+        c = self.config = load_config('~/.pgclirc', default_config)
+        self.smart_completion = c.getboolean('main', 'smart_completion')
+        self.multi_line = c.getboolean('main', 'multi_line')
+
+        self.logger = logging.getLogger(__name__)
+        self.initialize_logging()
+
+    def initialize_logging(self):
+
+        log_file = self.config.get('main', 'log_file')
+        log_level = self.config.get('main', 'log_level')
+
+        level_map = {'CRITICAL': logging.CRITICAL,
+                     'ERROR': logging.ERROR,
+                     'WARNING': logging.WARNING,
+                     'INFO': logging.INFO,
+                     'DEBUG': logging.DEBUG
+                     }
+
+        handler = logging.FileHandler(os.path.expanduser(log_file))
+
+        formatter = logging.Formatter(
+            '%(asctime)s (%(process)d/%(threadName)s) '
+            '%(name)s %(levelname)s - %(message)s')
+
+        handler.setFormatter(formatter)
+
+        self.logger.addHandler(handler)
+        self.logger.setLevel(level_map[log_level.upper()])
+
+        self.logger.debug('Initializing pgcli logging.')
+        self.logger.debug('Log file "%s".' % log_file)
+
+    def connect_uri(self, uri):
+        uri = urlparse(uri)
+        database = uri.path[1:]  # ignore the leading fwd slash
+        self.connect(database, uri.hostname, uri.username,
+                     uri.port, uri.password)
+
+    def connect(self, database='', host='', user='', port='', passwd=''):
+        # Connect to the database.
+
+        if not database:
+            #default to current OS username just like psql
+            database = user = getuser()
+
+        # Prompt for a password immediately if requested via the -W flag. This
+        # avoids wasting time trying to connect to the database and catching a
+        # no-password exception.
+        # If we successfully parsed a password from a URI, there's no need to
+        # prompt for it, even with the -W flag
+        if self.force_passwd_prompt and not passwd:
+            passwd = click.prompt('Password', hide_input=True,
+                                  show_default=False, type=str)
+
+        # Prompt for a password after 1st attempt to connect without a password
+        # fails. Don't prompt if the -w flag is supplied
+        auto_passwd_prompt = not passwd and not self.never_passwd_prompt
+
+        # Attempt to connect to the database.
+        # Note that passwd may be empty on the first attempt. If connection
+        # fails because of a missing password, but we're allowed to prompt for a
+        # password (no -w flag), prompt for a passwd and try again.
+        try:
+            try:
+                pgexecute = PGExecute(database, user, passwd, host, port)
+            except OperationalError as e:
+                if 'no password supplied' in e.message and auto_passwd_prompt:
+                    passwd = click.prompt('Password', hide_input=True,
+                                          show_default=False, type=str)
+                    pgexecute = PGExecute(database, user, passwd, host, port)
+                else:
+                    raise e
+
+        except Exception as e:  # Connecting to a database could fail.
+            self.logger.debug('Database connection failed: %r.', e)
+            click.secho(str(e), err=True, fg='red')
+            exit(1)
+
+        self.pgexecute = pgexecute
+
+    def run_cli(self):
+        pgexecute = self.pgexecute
+        prompt = '%s> ' % pgexecute.dbname
+        logger = self.logger
+        original_less_opts = self.adjust_less_opts()
+
+        layout = Layout(before_input=DefaultPrompt(prompt),
+            menus=[CompletionsMenu(max_height=10)],
+            lexer=SqlLexer, bottom_toolbars=[PGToolbar()])
+
+        completer = PGCompleter(self.smart_completion)
+        completer.extend_special_commands(CASE_SENSITIVE_COMMANDS.keys())
+        completer.extend_special_commands(NON_CASE_SENSITIVE_COMMANDS.keys())
+        refresh_completions(pgexecute, completer)
+        line = PGLine(always_multiline=self.multi_line, completer=completer,
+                history=FileHistory(os.path.expanduser('~/.pgcli-history')))
+        cli = CommandLineInterface(style=PGStyle, layout=layout, line=line,
+                key_binding_factories=[emacs_bindings, pgcli_bindings])
+
+        try:
+            while True:
+                cli.layout.before_input = DefaultPrompt(prompt)
+                document = cli.read_input(on_exit=AbortAction.RAISE_EXCEPTION)
+
+            # The reason we check here instead of inside the pgexecute is
+            # because we want to raise the Exit exception which will be caught
+            # by the try/except block that wraps the pgexecute.run() statement.
+                if quit_command(document.text):
+                    raise Exit
+                try:
+                    logger.debug('sql: %r', document.text)
+                    res = pgexecute.run(document.text)
+                    output = []
+                    for rows, headers, status in res:
+                        logger.debug("headers: %r", headers)
+                        logger.debug("rows: %r", rows)
+                        if rows:
+                            if is_expanded_output():
+                                output.append(expanded_table(rows, headers))
+                            else:
+                                output.append(tabulate(rows, headers, tablefmt='psql'))
+                        if status:  # Only print the status if it's not None.
+                            output.append(status)
+                        logger.debug("status: %r", status)
+                    click.echo_via_pager('\n'.join(output))
+                except Exception as e:
+                    logger.error("sql: %r, error: %r", document.text, e)
+                    logger.error("traceback: %r", traceback.format_exc())
+                    click.secho(str(e), err=True, fg='red')
+
+                # Refresh the table names and column names if necessary.
+                if need_completion_refresh(document.text):
+                    completer.reset_completions()
+                    refresh_completions(pgexecute, completer)
+        except Exit:
+            print ('GoodBye!')
+        finally:  # Reset the less opts back to original.
+            logger.debug('Restoring env var LESS to %r.', original_less_opts)
+            os.environ['LESS'] = original_less_opts
+
+    def adjust_less_opts(self):
+        less_opts = os.environ.get('LESS', '')
+        self.logger.debug('Original value for LESS env var: %r', less_opts)
+        if not less_opts:
+            os.environ['LESS'] = '-RXF'
+
+        if 'X' not in less_opts:
+            os.environ['LESS'] += 'X'
+        if 'F' not in less_opts:
+            os.environ['LESS'] += 'F'
+
+        return less_opts
 
 @click.command()
 
@@ -52,124 +220,21 @@ _logger = logging.getLogger(__name__)
 @click.argument('database', default='', envvar='PGDATABASE')
 def cli(database, user, host, port, prompt_passwd, never_prompt):
 
-    passwd = ''
-    if not database:
-        #default to current OS username just like psql
-        database = user = getuser()
-    elif '://' in database:
-        #a URI connection string
-        parsed = urlparse(database)
-        database = parsed.path[1:]  # ignore the leading fwd slash
-        user = parsed.username
-        passwd = parsed.password
-        port = parsed.port
-        host = parsed.hostname
+    pgcli = PGCli(prompt_passwd, never_prompt)
 
-    # Prompt for a password immediately if requested via the -W flag. This
-    # avoids wasting time trying to connect to the database and catching a
-    # no-password exception.
-    # If we successfully parsed a password from a URI, there's no need to prompt
-    # for it, even with the -W flag
-    if prompt_passwd and not passwd:
-        passwd = click.prompt('Password', hide_input=True, show_default=False,
-                type=str)
+    if '://' in database:
+        pgcli.connect_uri(database)
+    else:
+        pgcli.connect(database, host, user, port)
 
-    # Prompt for a password after 1st attempt to connect without a password
-    # fails. Don't prompt if the -w flag is supplied
-    auto_passwd_prompt = not passwd and not never_prompt
-
-    from pgcli import __file__ as package_root
-    package_root = os.path.dirname(package_root)
-
-    default_config = os.path.join(package_root, 'pgclirc')
-    write_default_config(default_config, '~/.pgclirc')
-
-    # Load config.
-    config = load_config('~/.pgclirc', default_config)
-    smart_completion = config.getboolean('main', 'smart_completion')
-    multi_line = config.getboolean('main', 'multi_line')
-    log_file = config.get('main', 'log_file')
-    log_level = config.get('main', 'log_level')
-
-    initialize_logging(log_file, log_level)
-
-    original_less_opts = adjust_less_opts()
-
-    _logger.debug('Launch Params: \n'
+    pgcli.logger.debug('Launch Params: \n'
             '\tdatabase: %r'
             '\tuser: %r'
-            '\tpassword: %r'
             '\thost: %r'
-            '\tport: %r', database, user, passwd, host, port)
+            '\tport: %r', database, user, host, port)
 
-    # Attempt to connect to the database.
-    # Note that passwd may be empty on the first attempt. If connection fails
-    # because of a missing password, but we're allowed to prompt for a password,
-    # (no -w flag), prompt for a passwd and try again.
-    try:
-        try:
-            pgexecute = PGExecute(database, user, passwd, host, port)
-        except OperationalError as e:
-            if 'no password supplied' in e.message and auto_passwd_prompt:
-                passwd = click.prompt('Password', hide_input=True,
-                                      show_default=False, type=str)
-                pgexecute = PGExecute(database, user, passwd, host, port)
-            else:
-                raise e
+    pgcli.run_cli()
 
-    except Exception as e:  # Connecting to a database could fail.
-        _logger.debug('Database connection failed: %r.', e)
-        click.secho(str(e), err=True, fg='red')
-        exit(1)
-    layout = Layout(before_input=DefaultPrompt('%s> ' % pgexecute.dbname),
-            menus=[CompletionsMenu(max_height=10)],
-            lexer=SqlLexer,
-            bottom_toolbars=[
-                PGToolbar()])
-    completer = PGCompleter(smart_completion)
-    completer.extend_special_commands(CASE_SENSITIVE_COMMANDS.keys())
-    completer.extend_special_commands(NON_CASE_SENSITIVE_COMMANDS.keys())
-    refresh_completions(pgexecute, completer)
-    line = PGLine(always_multiline=multi_line, completer=completer,
-            history=FileHistory(os.path.expanduser('~/.pgcli-history')))
-    cli = CommandLineInterface(style=PGStyle, layout=layout, line=line,
-            key_binding_factories=[emacs_bindings, pgcli_bindings])
-
-    try:
-        while True:
-            cli.layout.before_input = DefaultPrompt('%s> ' % pgexecute.dbname)
-            document = cli.read_input(on_exit=AbortAction.RAISE_EXCEPTION)
-
-            # The reason we check here instead of inside the pgexecute is
-            # because we want to raise the Exit exception which will be caught
-            # by the try/except block that wraps the pgexecute.run() statement.
-            if quit_command(document.text):
-                raise Exit
-            try:
-                _logger.debug('sql: %r', document.text)
-                res = pgexecute.run(document.text)
-
-                output = []
-                for rows, headers, status in res:
-                    _logger.debug("headers: %r", headers)
-                    _logger.debug("rows: %r", rows)
-                    _logger.debug("status: %r", status)
-                    output.extend(format_output(rows, headers, status))
-                click.echo_via_pager('\n'.join(output))
-            except Exception as e:
-                _logger.error("sql: %r, error: %r", document.text, e)
-                _logger.error("traceback: %r", traceback.format_exc())
-                click.secho(str(e), err=True, fg='red')
-
-            # Refresh the table names and column names if necessary.
-            if need_completion_refresh(document.text):
-                completer.reset_completions()
-                refresh_completions(pgexecute, completer)
-    except Exit:
-        print ('GoodBye!')
-    finally:  # Reset the less opts back to original.
-        _logger.debug('Restoring env var LESS to %r.', original_less_opts)
-        os.environ['LESS'] = original_less_opts
 
 def format_output(rows, headers, status):
     output = []
@@ -188,39 +253,6 @@ def need_completion_refresh(sql):
         return first_token.lower() in ('alter', 'create', 'use', '\c', 'drop')
     except Exception:
         return False
-
-def initialize_logging(log_file, log_level):
-    level_map = {'CRITICAL': logging.CRITICAL,
-                 'ERROR': logging.ERROR,
-                 'WARNING': logging.WARNING,
-                 'INFO': logging.INFO,
-                 'DEBUG': logging.DEBUG
-                 }
-
-    handler = logging.FileHandler(os.path.expanduser(log_file))
-
-    formatter = logging.Formatter('%(asctime)s (%(process)d/%(threadName)s) '
-              '%(name)s %(levelname)s - %(message)s')
-    handler.setFormatter(formatter)
-
-    _logger.addHandler(handler)
-    _logger.setLevel(level_map[log_level.upper()])
-
-    _logger.debug('Initializing pgcli logging.')
-    _logger.debug('Log file "%s".' % log_file)
-
-def adjust_less_opts():
-    less_opts = os.environ.get('LESS', '')
-    _logger.debug('Original value for LESS env var: %r', less_opts)
-    if not less_opts:
-        os.environ['LESS'] = '-RXF'
-
-    if 'X' not in less_opts:
-        os.environ['LESS'] += 'X'
-    if 'F' not in less_opts:
-        os.environ['LESS'] += 'F'
-
-    return less_opts
 
 def quit_command(sql):
     return (sql.strip().lower() == 'exit'


### PR DESCRIPTION
I really like @catherinedevlin's [ipython-sql](https://github.com/catherinedevlin/ipython-sql) for getting data from postgresql into python for data munging and visualization, but it's inconvenient writing queries in ipython without autocompletion and syntax highlighting. Since this is obviously pgcli's forte, it seems like the two projects really complement each other. This is my naive attempt to combine them. The general idea is you can drop into a pgcli session from ipython, iterate a query, then quit pgcli to find the query results in your ipython workspace. 

## Requirements
ipython-sql (`pip install ipython-sql`) 

## Usage
From an ipython console (not the notebook though, it'll hang), run `%load_ext pgcli.magic` to load the extension. This also loads the ipython-sql magic if it hasn't been already. Then the command `%pgcli postgresql://yourdbhere` should start a pgcli session. Quit the session with `\q` to return to ipython. The resultset from the last successful query should be available in the local variable `_`. See ipython-sql documentation for controlling the return type.

## Example
```
In [1]: %load_ext pgcli.magic

In [2]: %pgcli postgresql://dg@localhost/temp
temp> select generate_series(5, 10), random()
+-------------------+----------+
|   generate_series |   random |
|-------------------+----------|
|                 5 | 0.546024 |
|                 6 | 0.261947 |
|                 7 | 0.19185  |
|                 8 | 0.186082 |
|                 9 | 0.944421 |
|                10 | 0.963471 |
+-------------------+----------+
SELECT 6
temp> \q
GoodBye!
6 rows affected.
Out[2]:
[(5, 0.385186035186052),
 (6, 0.114940960425884),
 (7, 0.547451738733798),
 (8, 0.333624354097992),
 (9, 0.0919555663131177),
 (10, 0.453994856681675)]

In [3]: _[0]
Out[3]: (5, 0.385186035186052)
```

## TODO
- [x] Refactor most of pgcli.main into a standalone PGCli class. This should dovetail with #23 and other editor plugins
  - [x] Support querying the PGCli object for the last successful query after leaving a cli session
  - [ ] Persist the database connection between multiple %pgcli calls. 
- [ ] Better ipython-sql integration
  - [ ] %sql magic supports working with multiple database connections, and referring to previous connections with a username@hostname alias. %sql without any connection string simply reuses the previous connection. %pgcli should either attempt to emulate this, or even get database connections directly from %sql
  - [ ] Possibly pass a resultset directly to %sql instead of having it re-evaluate the query, which is not only inefficient but also dangerous if the query is mutating
- [ ] Plotting directly in pgcli. I'm envisioning something that lets you call matplotlib and treat the column names from the most recent query as local variables, like
```
> select foo from bar;
> \pylab hist(foo)
```
which should open a figure window with a histogram of the `foo` values
