### PR TITLE
Fix travis and build errors under python 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
-env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
 
-install: pip install tox
+install: 
+  - pip install . pytest mock
 
-script: tox -e $TOX_ENV
+script: py.test

--- a/pgcli/packages/expanded.py
+++ b/pgcli/packages/expanded.py
@@ -1,10 +1,12 @@
+from .tabulate import _text_type
+
 def pad(field, total, char=u" "):
     return field + (char * (total - len(field)))
 
 def get_separator(num, header_len, data_len):
     total_len = header_len + data_len + 1
 
-    sep = u"-[ RECORD {0} ]".format(unicode(num))
+    sep = u"-[ RECORD {0} ]".format(num)
     if len(sep) < header_len:
         sep = pad(sep, header_len - 1, u"-") + u"+"
 
@@ -22,13 +24,13 @@ def expanded_table(rows, headers):
     header_len += 2
 
     for row in rows:
-        row_len = max([len(str(x)) for x in row])
+        row_len = max([len(_text_type(x)) for x in row])
         row_result = ""
         if row_len > max_row_len:
             max_row_len = row_len
 
         for item in zip(padded_headers, row):
-            row_result += item[0] + u" " + unicode(item[1]) + u"\n"
+            row_result += u"{0} {1}\n".format(item[0], item[1])
 
         results.append(row_result)
 
@@ -38,4 +40,3 @@ def expanded_table(rows, headers):
         output += result
 
     return output
-

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts=--capture=sys --showlocals

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -1,3 +1,5 @@
+# coding=UTF-8
+
 from pgcli.pgexecute import _parse_dsn
 from textwrap import dedent
 from utils import *
@@ -66,3 +68,17 @@ def test_table_and_columns_query(executor):
 def test_database_list(executor):
     databases = executor.databases()
     assert '_test_db' in databases
+
+@pytest.fixture(params=[True, False])
+def expanded(request):
+    return request.param
+
+@dbtest
+def test_unicode_support_in_output(executor, expanded):
+    if expanded:
+        run(executor, '\\x')
+    run(executor, "create table unicodechars(t text)")
+    run(executor, "insert into unicodechars (t) values ('é')")
+
+    # See issue #24, this raises an exception without proper handling
+    assert u'é' in run(executor, "select * from unicodechars", join=True)

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@ envlist = py26, py27, py33, py34
 [testenv]
 deps = pytest
     mock
-commands = py.test --capture=sys --showlocals
+commands = py.test


### PR DESCRIPTION
PR #71 introduced a bug, where the python version that was used by travis did not match the version intended.

Also fix the problems plaguing current master builds failing under python 3, with tests! :)

@amjith