### PR TITLE
Fix auto passwd prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+pyvenv/
 build/
 develop-eggs/
 dist/
@@ -55,3 +56,4 @@ target/
 
 # PyCharm
 .idea/
+*.iml

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -122,7 +122,7 @@ class PGCli(object):
             try:
                 pgexecute = PGExecute(database, user, passwd, host, port)
             except OperationalError as e:
-                if 'no password supplied' in e.message and auto_passwd_prompt:
+                if 'no password supplied' in e.args[0] and auto_passwd_prompt:
                     passwd = click.prompt('Password', hide_input=True,
                                           show_default=False, type=str)
                     pgexecute = PGExecute(database, user, passwd, host, port)


### PR DESCRIPTION
Hi,

On Linux, with Python 3.4.2 and psycopg2 2.5.4, I have this error when I try to connect to a database with a password:
<pre>(pyvenv) lg@steroids:~/Documents/IDEA/LGbo$ pgcli -h localhost -p 5432 -U asterisk asterisk
'OperationalError' object has no attribute 'message'</pre>

With this commit, I have no more issues.
I've quickly tested with Python 2.7.6, it continues to work.

Regards.