### PR TITLE
Make autocomplete schema-aware

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -332,11 +332,9 @@ def quit_command(sql):
             or sql.strip() == ':q')
 
 def refresh_completions(pgexecute, completer):
-    tables, columns = pgexecute.tables()
-    completer.extend_table_names(tables)
-    for table in tables:
-        table = table[1:-1] if table[0] == '"' and table[-1] == '"' else table
-        completer.extend_column_names(table, columns[table])
+    tables, columns = pgexecute.get_metadata()
+    completer.extend_tables(tables)
+    completer.extend_columns(columns)
     completer.extend_database_names(pgexecute.databases())
 
 if __name__ == "__main__":

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -267,10 +267,10 @@ class PGCli(object):
 
         pgexecute = self.pgexecute
 
-        schemata, tables, columns = pgexecute.get_metadata()
-        completer.extend_schemata(schemata)
-        completer.extend_tables(tables)
-        completer.extend_columns(columns)
+        completer.set_search_path(pgexecute.search_path())
+        completer.extend_schemata(pgexecute.schemata())
+        completer.extend_tables(pgexecute.tables())
+        completer.extend_columns(pgexecute.columns())
         completer.extend_database_names(pgexecute.databases())
 
     def get_completions(self, text, cursor_positition):

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -352,13 +352,5 @@ def quit_command(sql):
             or sql.strip() == '\q'
             or sql.strip() == ':q')
 
-def refresh_completions(pgexecute, completer):
-    tables, columns = pgexecute.tables()
-    completer.extend_table_names(tables)
-    for table in tables:
-        table = table[1:-1] if table[0] == '"' and table[-1] == '"' else table
-        completer.extend_column_names(table, columns[table])
-    completer.extend_database_names(pgexecute.databases())
-
 if __name__ == "__main__":
     cli()

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -332,7 +332,8 @@ def quit_command(sql):
             or sql.strip() == ':q')
 
 def refresh_completions(pgexecute, completer):
-    tables, columns = pgexecute.get_metadata()
+    schemata, tables, columns = pgexecute.get_metadata()
+    completer.extend_schemata(schemata)
     completer.extend_tables(tables)
     completer.extend_columns(columns)
     completer.extend_database_names(pgexecute.databases())

--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import re
 import sqlparse
-from pandas import DataFrame
 from sqlparse.sql import IdentifierList, Identifier, Function
 from sqlparse.tokens import Keyword, DML, Punctuation
 
@@ -132,12 +131,12 @@ def extract_table_identifiers(token_stream):
 def extract_tables(sql):
     """Extract the table names from an SQL statment.
 
-    Returns a DataFrame with columns [schema, table, alias]
+    Returns a list of (schema, table, alias) tuples
 
     """
     parsed = sqlparse.parse(sql)
     if not parsed:
-        return DataFrame({}, columns=['schema', 'table', 'alias'])
+        return []
 
     # INSERT statements must stop looking for tables at the sign of first
     # Punctuation. eg: INSERT INTO abc (col1, col2) VALUES (1, 2)
@@ -145,8 +144,7 @@ def extract_tables(sql):
     # we'll identify abc, col1 and col2 as table names.
     insert_stmt = parsed[0].token_first().value.lower() == 'insert'
     stream = extract_from_part(parsed[0], stop_at_punctuation=insert_stmt)
-    tables = extract_table_identifiers(stream)
-    return DataFrame.from_records(tables, columns=['schema', 'table', 'alias'])
+    return list(extract_table_identifiers(stream))
 
 def find_prev_keyword(sql):
     if not sql.strip():

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -85,7 +85,7 @@ class PGCompleter(Completer):
     def extend_schemata(self, data):
 
         # data is a DataFrame with columns [schema]
-        data['schema'] = data['schema'].apply(self.unescape_name)
+        data['schema'] = data['schema'].apply(self.escape_name)
         self.schemata = self.schemata.append(data)
         self.all_completions.update(data['schema'])
 
@@ -93,7 +93,7 @@ class PGCompleter(Completer):
 
         # data is a DataFrame with columns [schema, table, is_visible]
         data[['schema', 'table']] = \
-            data[['schema', 'table']].apply(self.unescaped_names)
+            data[['schema', 'table']].apply(self.escaped_names)
         self.tables = self.tables.append(data)
 
         self.all_completions.update(data['schema'])
@@ -108,7 +108,7 @@ class PGCompleter(Completer):
 
         # data is a DataFrame with columns [schema, table, column]
         data[['schema', 'table', 'column']] = \
-            data[['schema', 'table', 'column']].apply(self.unescaped_names)
+            data[['schema', 'table', 'column']].apply(self.escaped_names)
         self.columns = self.columns.append(data)
         self.all_completions.update(data.column)
 
@@ -192,7 +192,7 @@ class PGCompleter(Completer):
         columns = self.columns  # dataframe with columns [schema, table, column]
 
         scoped_tbls[['schema', 'table', 'alias']] = \
-            scoped_tbls[['schema', 'table', 'alias']].apply(self.unescaped_names)
+            scoped_tbls[['schema', 'table', 'alias']].apply(self.escaped_names)
 
         # For fully qualified tables, inner join on (schema, table)
         qualed = scoped_tbls.merge(columns, how='inner', on=['schema', 'table'])

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -22,7 +22,7 @@ class PGCompleter(Completer):
             'MAXEXTENTS', 'MINUS', 'MLSLABEL', 'MODE', 'MODIFY', 'NOAUDIT',
             'NOCOMPRESS', 'NOT', 'NOWAIT', 'NULL', 'NUMBER', 'OF', 'OFFLINE',
             'ON', 'ONLINE', 'OPTION', 'OR', 'ORDER BY', 'OUTER', 'PCTFREE',
-            'PRIMARY', 'PRIOR', 'PRIVILEGES', 'PUBLIC', 'RAW', 'RENAME',
+            'PRIMARY', 'PRIOR', 'PRIVILEGES', 'RAW', 'RENAME',
             'RESOURCE', 'REVOKE', 'RIGHT', 'ROW', 'ROWID', 'ROWNUM', 'ROWS',
             'SELECT', 'SESSION', 'SET', 'SHARE', 'SIZE', 'SMALLINT', 'START',
             'SUCCESSFUL', 'SYNONYM', 'SYSDATE', 'TABLE', 'THEN', 'TO',

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -155,8 +155,9 @@ class PGCompleter(Completer):
                 completions.extend(funcs)
 
             elif suggestion['type'] == 'schema':
-                schemata = self.find_matches(word_before_cursor, self.schemata)
-                completions.extend(schemata)
+                schema_names = self.schemata['schema']
+                schema_names = self.find_matches(word_before_cursor, schema_names)
+                completions.extend(schema_names)
 
             elif suggestion['type'] == 'table':
                 meta = self.tables

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -37,7 +37,7 @@ class PGCompleter(Completer):
     special_commands = []
 
     databases = []
-    schemata = set()
+    schemata = DataFrame({}, columns=['schema'])
     tables = DataFrame({}, columns=['schema', 'table', 'alias'])
     columns = DataFrame({}, columns=['schema', 'table', 'column'])
 
@@ -78,13 +78,18 @@ class PGCompleter(Completer):
         self.keywords.extend(additional_keywords)
         self.all_completions.update(additional_keywords)
 
+    def extend_schemata(self, data):
+
+        # data is a DataFrame with columns [schema]
+        self.schemata = self.schemata.append(data)
+        self.all_completions.update(data['schema'])
+
     def extend_tables(self, data):
 
         # data is a DataFrame with columns [schema, table, is_visible]
         data[['schema', 'table']].apply(self.escaped_names)
         self.tables = self.tables.append(data)
 
-        self.schemata.update(data['schema'])
         self.all_completions.update(data['schema'])
         self.all_completions.update(data['table'])
 
@@ -102,7 +107,7 @@ class PGCompleter(Completer):
 
     def reset_completions(self):
         self.databases = []
-        self.schemata = set()
+        self.schemata = DataFrame({}, columns=['schema'])
         self.tables = DataFrame({}, columns=['schema', 'table', 'alias'])
         self.columns = DataFrame({}, columns=['schema', 'table', 'column'])
         self.all_completions = set(self.keywords)

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -85,13 +85,15 @@ class PGCompleter(Completer):
     def extend_schemata(self, data):
 
         # data is a DataFrame with columns [schema]
+        data['schema'] = data['schema'].apply(self.unescape_name)
         self.schemata = self.schemata.append(data)
         self.all_completions.update(data['schema'])
 
     def extend_tables(self, data):
 
         # data is a DataFrame with columns [schema, table, is_visible]
-        data[['schema', 'table']].apply(self.escaped_names)
+        data[['schema', 'table']] = \
+            data[['schema', 'table']].apply(self.unescaped_names)
         self.tables = self.tables.append(data)
 
         self.all_completions.update(data['schema'])
@@ -105,7 +107,8 @@ class PGCompleter(Completer):
     def extend_columns(self, data):
 
         # data is a DataFrame with columns [schema, table, column]
-        data[['schema', 'table', 'column']].apply(self.escaped_names)
+        data[['schema', 'table', 'column']] = \
+            data[['schema', 'table', 'column']].apply(self.unescaped_names)
         self.columns = self.columns.append(data)
         self.all_completions.update(data.column)
 
@@ -188,7 +191,8 @@ class PGCompleter(Completer):
 
         columns = self.columns  # dataframe with columns [schema, table, column]
 
-        scoped_tbls[['schema', 'table', 'alias']].apply(self.unescape_name)
+        scoped_tbls[['schema', 'table', 'alias']] = \
+            scoped_tbls[['schema', 'table', 'alias']].apply(self.unescaped_names)
 
         # For fully qualified tables, inner join on (schema, table)
         qualed = scoped_tbls.merge(columns, how='inner', on=['schema', 'table'])

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -52,7 +52,7 @@ class PGCompleter(Completer):
         self.name_pattern = compile("^[_a-z][_a-z0-9\$]*$")
 
     def escape_name(self, name):
-        if ((not self.name_pattern.match(name))
+        if name and not name=='*' and ((not self.name_pattern.match(name))
                 or (name.upper() in self.reserved_words)
                 or (name.upper() in self.functions)):
             name = '"%s"' % name
@@ -61,7 +61,7 @@ class PGCompleter(Completer):
 
     def unescape_name(self, name):
         """ Unquote a string."""
-        if name[0] == '"' and name[-1] == '"':
+        if name and name[0] == '"' and name[-1] == '"':
             name = name[1:-1]
 
         return name

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -200,8 +200,10 @@ class PGCompleter(Completer):
 
         # Only allow unqualified table reference on visible tables
         vis_tables = self.tables[self.tables['is_visible']]
-        unqualed_tables = scoped_tbls.merge(vis_tables, how='inner', on=['table'])
-        unqualed = unqualed_tables.merge(columns, how='inner', on=['table'])
+        unqualed_tables = scoped_tbls.merge(vis_tables,
+            how='inner', on=['table'], suffixes=['_left', '_right'])
+        unqualed_tables['schema'] = unqualed_tables['schema_right']
+        unqualed = unqualed_tables.merge(columns, how='inner', on=['schema', 'table'])
 
         return list(qualed['column']) + list(unqualed['column'])
 

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -33,13 +33,6 @@ class PGCompleter(Completer):
             'LCASE', 'LEN', 'MAX', 'MIN', 'MID', 'NOW', 'ROUND', 'SUM', 'TOP',
             'UCASE']
 
-    special_commands = []
-    databases = []
-    dbmetadata = {}
-    search_path = []
-
-    all_completions = set(keywords + functions)
-
     def __init__(self, smart_completion=True):
         super(self.__class__, self).__init__()
         self.smart_completion = smart_completion
@@ -47,6 +40,13 @@ class PGCompleter(Completer):
         for x in self.keywords:
             self.reserved_words.update(x.split())
         self.name_pattern = compile("^[_a-z][_a-z0-9\$]*$")
+
+        self.special_commands = []
+        self.databases = []
+        self.dbmetadata = {}
+        self.search_path = []
+
+        self.all_completions = set(self.keywords + self.functions)
 
     def escape_name(self, name):
         if name and ((not self.name_pattern.match(name))

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,7 @@ setup(
             'jedi == 0.8.1',    # Temporary fix for installation woes.
             'prompt_toolkit==0.26',
             'psycopg2 >= 2.5.4',
-            'sqlparse >= 0.1.14',
-            'pandas >= 0.15.0'
+            'sqlparse >= 0.1.14'
             ],
         entry_points='''
             [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
             'prompt_toolkit==0.26',
             'psycopg2 >= 2.5.4',
             'sqlparse >= 0.1.14',
+            'pandas >= 0.15.0'
             ],
         entry_points='''
             [console_scripts]

--- a/tests/test_parseutils.py
+++ b/tests/test_parseutils.py
@@ -1,3 +1,4 @@
+import pytest
 from pgcli.packages.parseutils import extract_tables
 
 

--- a/tests/test_parseutils.py
+++ b/tests/test_parseutils.py
@@ -4,114 +4,81 @@ from pgcli.packages.parseutils import extract_tables
 
 def test_empty_string():
     tables = extract_tables('')
-    assert tables.to_dict('list') == {'schema': [], 'table': [], 'alias': []}
+    assert tables == []
 
 def test_simple_select_single_table():
     tables = extract_tables('select * from abc')
-    assert tables.to_dict('list') == \
-           {'schema': [None], 'table': ['abc'], 'alias': [None]}
+    assert tables == [(None, 'abc', None)]
 
 def test_simple_select_single_table_schema_qualified():
     tables = extract_tables('select * from abc.def')
-    assert tables.to_dict('list') == \
-           {'schema': ['abc'], 'table': ['def'], 'alias': [None]}
+    assert tables == [('abc', 'def', None)]
 
 def test_simple_select_multiple_tables():
     tables = extract_tables('select * from abc, def')
-    assert tables.to_dict('list') == \
-           {'schema': [None, None],
-            'table': ['abc', 'def'],
-            'alias': [None, None]}
+    assert sorted(tables) == [(None, 'abc', None), (None, 'def', None)]
 
 def test_simple_select_multiple_tables_schema_qualified():
     tables = extract_tables('select * from abc.def, ghi.jkl')
-    assert tables.to_dict('list') == \
-           {'schema': ['abc', 'ghi'],
-            'table': ['def', 'jkl'],
-            'alias': [None, None]}
+    assert sorted(tables) == [('abc', 'def', None), ('ghi', 'jkl', None)]
 
 def test_simple_select_with_cols_single_table():
     tables = extract_tables('select a,b from abc')
-    assert tables.to_dict('list') == \
-           {'schema': [None], 'table': ['abc'], 'alias': [None]}
+    assert tables == [(None, 'abc', None)]
 
 def test_simple_select_with_cols_single_table_schema_qualified():
     tables = extract_tables('select a,b from abc.def')
-    assert tables.to_dict('list') == \
-           {'schema': ['abc'], 'table': ['def'], 'alias': [None]}
+    assert tables == [('abc', 'def', None)]
 
 def test_simple_select_with_cols_multiple_tables():
     tables = extract_tables('select a,b from abc, def')
-    assert tables.to_dict('list') == \
-           {'schema': [None, None],
-            'table': ['abc', 'def'],
-            'alias': [None, None]}
+    assert sorted(tables) == [(None, 'abc', None), (None, 'def', None)]
 
 def test_simple_select_with_cols_multiple_tables():
     tables = extract_tables('select a,b from abc.def, def.ghi')
-    assert tables.to_dict('list') == \
-           {'schema': ['abc', 'def'],
-            'table': ['def', 'ghi'],
-            'alias': [None, None]}
+    assert sorted(tables) == [('abc', 'def', None), ('def', 'ghi', None)]
 
 def test_select_with_hanging_comma_single_table():
     tables = extract_tables('select a, from abc')
-    assert tables.to_dict('list') == \
-           {'schema': [None],
-            'table': ['abc'],
-            'alias': [None]}
+    assert tables == [(None, 'abc', None)]
 
 def test_select_with_hanging_comma_multiple_tables():
     tables = extract_tables('select a, from abc, def')
-    assert tables.to_dict('list') == \
-           {'schema': [None, None],
-            'table': ['abc', 'def'],
-            'alias': [None, None]}
+    assert sorted(tables) == [(None, 'abc', None), (None, 'def', None)]
 
 def test_select_with_hanging_period_multiple_tables():
     tables = extract_tables('SELECT t1. FROM tabl1 t1, tabl2 t2')
-    assert tables.to_dict('list') == \
-           {'schema': [None, None],
-            'table': ['tabl1', 'tabl2'],
-            'alias': ['t1', 't2']}
+    assert sorted(tables) == [(None, 'tabl1', 't1'), (None, 'tabl2', 't2')]
 
 def test_simple_insert_single_table():
     tables = extract_tables('insert into abc (id, name) values (1, "def")')
-    assert tables.to_dict('list') == \
-           {'schema': [None], 'table': ['abc'], 'alias': ['abc']}
+
+    # sqlparse mistakenly assigns an alias to the table
+    # assert tables == [(None, 'abc', None)]
+    assert tables == [(None, 'abc', 'abc')]
 
 @pytest.mark.xfail
 def test_simple_insert_single_table_schema_qualified():
     tables = extract_tables('insert into abc.def (id, name) values (1, "def")')
-    assert tables.to_dict('list') == \
-           {'schema': ['abc'], 'table': ['def'], 'alias': [None]}
+    assert tables == [('abc', 'def', None)]
 
 def test_simple_update_table():
     tables = extract_tables('update abc set id = 1')
-    assert tables.to_dict('list') == \
-           {'schema': [None], 'table': ['abc'], 'alias': [None]}
+    assert tables == [(None, 'abc', None)]
 
 def test_simple_update_table():
     tables = extract_tables('update abc.def set id = 1')
-    assert tables.to_dict('list') == \
-           {'schema': ['abc'], 'table': ['def'], 'alias': [None]}
+    assert tables == [('abc', 'def', None)]
 
 def test_join_table():
     tables = extract_tables('SELECT * FROM abc a JOIN def d ON a.id = d.num')
-    assert tables.to_dict('list') == \
-           {'schema': [None, None],
-            'table': ['abc', 'def'],
-            'alias': ['a', 'd']}
+    assert sorted(tables) == [(None, 'abc', 'a'), (None, 'def', 'd')]
 
 def test_join_table_schema_qualified():
     tables = extract_tables('SELECT * FROM abc.def x JOIN ghi.jkl y ON x.id = y.num')
-    assert tables.to_dict('list') == \
-           {'schema': ['abc', 'ghi'],
-            'table': ['def', 'jkl'],
-            'alias': ['x', 'y']}
+    assert tables == [('abc', 'def', 'x'), ('ghi', 'jkl', 'y')]
 
 def test_join_as_table():
     tables = extract_tables('SELECT * FROM my_table AS m WHERE m.a > 5')
-    assert tables.to_dict('list') == \
-           {'schema': [None], 'table': ['my_table'], 'alias': ['m']}
+    assert tables == [(None, 'my_table', 'm')]
 

--- a/tests/test_parseutils.py
+++ b/tests/test_parseutils.py
@@ -3,52 +3,114 @@ from pgcli.packages.parseutils import extract_tables
 
 def test_empty_string():
     tables = extract_tables('')
-    assert tables == []
+    assert tables.to_dict('list') == {'schema': [], 'table': [], 'alias': []}
 
 def test_simple_select_single_table():
     tables = extract_tables('select * from abc')
-    assert tables == ['abc']
+    assert tables.to_dict('list') == \
+           {'schema': [None], 'table': ['abc'], 'alias': [None]}
+
+def test_simple_select_single_table_schema_qualified():
+    tables = extract_tables('select * from abc.def')
+    assert tables.to_dict('list') == \
+           {'schema': ['abc'], 'table': ['def'], 'alias': [None]}
 
 def test_simple_select_multiple_tables():
     tables = extract_tables('select * from abc, def')
-    assert tables == ['abc', 'def']
+    assert tables.to_dict('list') == \
+           {'schema': [None, None],
+            'table': ['abc', 'def'],
+            'alias': [None, None]}
+
+def test_simple_select_multiple_tables_schema_qualified():
+    tables = extract_tables('select * from abc.def, ghi.jkl')
+    assert tables.to_dict('list') == \
+           {'schema': ['abc', 'ghi'],
+            'table': ['def', 'jkl'],
+            'alias': [None, None]}
 
 def test_simple_select_with_cols_single_table():
     tables = extract_tables('select a,b from abc')
-    assert tables == ['abc']
+    assert tables.to_dict('list') == \
+           {'schema': [None], 'table': ['abc'], 'alias': [None]}
+
+def test_simple_select_with_cols_single_table_schema_qualified():
+    tables = extract_tables('select a,b from abc.def')
+    assert tables.to_dict('list') == \
+           {'schema': ['abc'], 'table': ['def'], 'alias': [None]}
 
 def test_simple_select_with_cols_multiple_tables():
     tables = extract_tables('select a,b from abc, def')
-    assert tables == ['abc', 'def']
+    assert tables.to_dict('list') == \
+           {'schema': [None, None],
+            'table': ['abc', 'def'],
+            'alias': [None, None]}
+
+def test_simple_select_with_cols_multiple_tables():
+    tables = extract_tables('select a,b from abc.def, def.ghi')
+    assert tables.to_dict('list') == \
+           {'schema': ['abc', 'def'],
+            'table': ['def', 'ghi'],
+            'alias': [None, None]}
 
 def test_select_with_hanging_comma_single_table():
     tables = extract_tables('select a, from abc')
-    assert tables == ['abc']
+    assert tables.to_dict('list') == \
+           {'schema': [None],
+            'table': ['abc'],
+            'alias': [None]}
 
 def test_select_with_hanging_comma_multiple_tables():
     tables = extract_tables('select a, from abc, def')
-    assert tables == ['abc', 'def']
+    assert tables.to_dict('list') == \
+           {'schema': [None, None],
+            'table': ['abc', 'def'],
+            'alias': [None, None]}
+
+def test_select_with_hanging_period_multiple_tables():
+    tables = extract_tables('SELECT t1. FROM tabl1 t1, tabl2 t2')
+    assert tables.to_dict('list') == \
+           {'schema': [None, None],
+            'table': ['tabl1', 'tabl2'],
+            'alias': ['t1', 't2']}
 
 def test_simple_insert_single_table():
     tables = extract_tables('insert into abc (id, name) values (1, "def")')
-    assert tables == ['abc']
+    assert tables.to_dict('list') == \
+           {'schema': [None], 'table': ['abc'], 'alias': ['abc']}
+
+@pytest.mark.xfail
+def test_simple_insert_single_table_schema_qualified():
+    tables = extract_tables('insert into abc.def (id, name) values (1, "def")')
+    assert tables.to_dict('list') == \
+           {'schema': ['abc'], 'table': ['def'], 'alias': [None]}
 
 def test_simple_update_table():
     tables = extract_tables('update abc set id = 1')
-    assert tables == ['abc']
+    assert tables.to_dict('list') == \
+           {'schema': [None], 'table': ['abc'], 'alias': [None]}
+
+def test_simple_update_table():
+    tables = extract_tables('update abc.def set id = 1')
+    assert tables.to_dict('list') == \
+           {'schema': ['abc'], 'table': ['def'], 'alias': [None]}
 
 def test_join_table():
-    expected = {'a': 'abc', 'd': 'def'}
     tables = extract_tables('SELECT * FROM abc a JOIN def d ON a.id = d.num')
-    tables_aliases = extract_tables(
-            'SELECT * FROM abc a JOIN def d ON a.id = d.num', True)
-    assert tables == sorted(expected.values())
-    assert tables_aliases == expected
+    assert tables.to_dict('list') == \
+           {'schema': [None, None],
+            'table': ['abc', 'def'],
+            'alias': ['a', 'd']}
+
+def test_join_table_schema_qualified():
+    tables = extract_tables('SELECT * FROM abc.def x JOIN ghi.jkl y ON x.id = y.num')
+    assert tables.to_dict('list') == \
+           {'schema': ['abc', 'ghi'],
+            'table': ['def', 'jkl'],
+            'alias': ['x', 'y']}
 
 def test_join_as_table():
-    expected = {'m': 'my_table'}
-    assert extract_tables(
-            'SELECT * FROM my_table AS m WHERE m.a > 5') == \
-                    sorted(expected.values())
-    assert extract_tables(
-            'SELECT * FROM my_table AS m WHERE m.a > 5', True) == expected
+    tables = extract_tables('SELECT * FROM my_table AS m WHERE m.a > 5')
+    assert tables.to_dict('list') == \
+           {'schema': [None], 'table': ['my_table'], 'alias': ['m']}
+

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -59,10 +59,10 @@ def test_table_and_columns_query(executor):
     run(executor, "create table a(x text, y text)")
     run(executor, "create table b(z text)")
 
-    tables, columns = executor.tables()
-    assert tables == ['a', 'b']
-    assert columns['a'] == ['x', 'y']
-    assert columns['b'] == ['z']
+    tables, columns = executor.get_metadata()
+    assert set(tables['table']) == set(['a', 'b'])
+    assert set(columns['column'][columns['table']=='a']) == set(['x', 'y'])
+    assert set(columns['column'][columns['table']=='b']) == set(['z'])
 
 @dbtest
 def test_database_list(executor):

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -23,18 +23,15 @@ def test_schemata_table_and_columns_query(executor):
     run(executor, "create table schema1.c (w text)")
     run(executor, "create schema schema2")
 
-    schemata, tables, columns = executor.get_metadata()
-    assert schemata.to_dict('list') == {
-        'schema': ['public', 'schema1', 'schema2']}
-    assert tables.to_dict('list') == {
-           'schema': ['public', 'public', 'schema1'],
-           'table': ['a', 'b', 'c'],
-           'is_visible': [True, True, False]}
+    assert executor.schemata() == ['public', 'schema1', 'schema2']
+    assert executor.tables() == [
+        ('public', 'a'), ('public', 'b'), ('schema1', 'c')]
 
-    assert columns.to_dict('list') == {
-           'schema': ['public', 'public', 'public', 'schema1'],
-           'table': ['a', 'a', 'b', 'c'],
-           'column': ['x', 'y', 'z', 'w']}
+    assert executor.columns() == [
+        ('public', 'a', 'x'), ('public', 'a', 'y'),
+        ('public', 'b', 'z'), ('schema1', 'c', 'w')]
+
+    assert executor.search_path() == ['public']
 
 @dbtest
 def test_database_list(executor):

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -55,14 +55,25 @@ def test_conn(executor):
         SELECT 1""")
 
 @dbtest
-def test_table_and_columns_query(executor):
+def test_schemata_table_and_columns_query(executor):
     run(executor, "create table a(x text, y text)")
     run(executor, "create table b(z text)")
+    run(executor, "create schema schema1")
+    run(executor, "create table schema1.c (w text)")
+    run(executor, "create schema schema2")
 
-    tables, columns = executor.get_metadata()
-    assert set(tables['table']) == set(['a', 'b'])
-    assert set(columns['column'][columns['table']=='a']) == set(['x', 'y'])
-    assert set(columns['column'][columns['table']=='b']) == set(['z'])
+    schemata, tables, columns = executor.get_metadata()
+    assert schemata.to_dict('list') == {
+        'schema': ['public', 'schema1', 'schema2']}
+    assert tables.to_dict('list') == {
+           'schema': ['public', 'public', 'schema1'],
+           'table': ['a', 'b', 'c'],
+           'is_visible': [True, True, False]}
+
+    assert columns.to_dict('list') == {
+           'schema': ['public', 'public', 'public', 'schema1'],
+           'table': ['a', 'a', 'b', 'c'],
+           'column': ['x', 'y', 'z', 'w']}
 
 @dbtest
 def test_database_list(executor):

--- a/tests/test_pgspecial.py
+++ b/tests/test_pgspecial.py
@@ -1,0 +1,19 @@
+from pgcli.packages.sqlcompletion import suggest_type
+from test_sqlcompletion import sorted_dicts
+
+def test_d_suggests_tables_and_schemas():
+    suggestions = suggest_type('\d ', '\d ')
+    assert sorted_dicts(suggestions) == sorted_dicts([
+            {'type': 'schema'}, {'type': 'table', 'schema': []}])
+
+    suggestions = suggest_type('\d xxx', '\d xxx')
+    assert sorted_dicts(suggestions) == sorted_dicts([
+            {'type': 'schema'}, {'type': 'table', 'schema': []}])
+
+def test_d_dot_suggests_schema_qualified_tables():
+    suggestions = suggest_type('\d myschema.', '\d myschema.')
+    assert suggestions == [{'type': 'table', 'schema': 'myschema'}]
+
+    suggestions = suggest_type('\d myschema.xxx', '\d myschema.xxx')
+    assert suggestions == [{'type': 'table', 'schema': 'myschema'}]
+

--- a/tests/test_smart_completion.py
+++ b/tests/test_smart_completion.py
@@ -36,7 +36,7 @@ def completer():
                     for column in columns),
         columns=['schema', 'table', 'column'])
 
-
+    comp.extend_schemata(tables[['schema']].drop_duplicates())
     comp.extend_tables(tables)
     comp.extend_columns(columns)
 
@@ -73,6 +73,7 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     assert set(result) == set([Completion(text='public', start_position=0),
                                Completion(text='custom', start_position=0),
                                Completion(text='users', start_position=0),
+                               Completion(text='"select"', start_position=0),
                                Completion(text='orders', start_position=0)])
 
 
@@ -276,6 +277,8 @@ def test_table_names_after_from(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
+        Completion(text='public', start_position=0),
+        Completion(text='custom', start_position=0),
         Completion(text='users', start_position=0),
         Completion(text='orders', start_position=0),
         Completion(text='"select"', start_position=0),

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -3,15 +3,9 @@ from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
 
 metadata = {
-            'public':   {
-                            'users': ['id', 'email', 'first_name', 'last_name'],
-                            'orders': ['id', 'ordered_date', 'status'],
-                            'select': ['id', 'insert', 'ABC'],
-                        },
-            'custom':   {
-                            'products': ['id', 'product_name', 'price'],
-                            'shipments': ['id', 'address', 'user_id']
-                        }
+                'users': ['id', 'email', 'first_name', 'last_name'],
+                'orders': ['id', 'ordered_date', 'status'],
+                'select': ['id', 'insert', 'ABC']
             }
 
 @pytest.fixture
@@ -20,14 +14,12 @@ def completer():
     import pgcli.pgcompleter as pgcompleter
     comp = pgcompleter.PGCompleter(smart_completion=True)
 
-    schemata, tables, columns = [], [], []
+    schemata = ['public']
+    tables, columns = [], []
 
-    for schema, tbls in metadata.items():
-        schemata.append(schema)
-
-        for table, cols in tbls.items():
-            tables.append((schema, table))
-            columns.extend([(schema, table, col) for col in cols])
+    for table, cols in metadata.items():
+        tables.append(('public', table))
+        columns.extend([('public', table, col) for col in cols])
 
     comp.extend_schemata(schemata)
     comp.extend_tables(tables)
@@ -65,7 +57,6 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([Completion(text='public', start_position=0),
-                               Completion(text='custom', start_position=0),
                                Completion(text='users', start_position=0),
                                Completion(text='"select"', start_position=0),
                                Completion(text='orders', start_position=0)])
@@ -96,24 +87,6 @@ def test_suggested_column_names_from_visible_table(completer, complete_event):
         Completion(text='email', start_position=0),
         Completion(text='first_name', start_position=0),
         Completion(text='last_name', start_position=0)] +
-        list(map(Completion, completer.functions)))
-
-def test_suggested_column_names_from_schema_qualifed_table(completer, complete_event):
-    """
-    Suggest column and function names when selecting from a qualified-table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
-    text = 'SELECT  from custom.products'
-    position = len('SELECT ')
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position), complete_event))
-    assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='product_name', start_position=0),
-        Completion(text='price', start_position=0)] +
         list(map(Completion, completer.functions)))
 
 def test_suggested_column_names_in_function(completer, complete_event):
@@ -154,15 +127,6 @@ def test_suggested_column_names_with_table_dot(completer, complete_event):
         Completion(text='email', start_position=0),
         Completion(text='first_name', start_position=0),
         Completion(text='last_name', start_position=0)])
-
-def test_suggested_table_names_with_schema_dot(completer, complete_event):
-    text = 'SELECT * FROM custom.'
-    position = len(text)
-    result = completer.get_completions(
-        Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set([
-        Completion(text='products', start_position=0),
-        Completion(text='shipments', start_position=0)])
 
 def test_suggested_column_names_with_alias(completer, complete_event):
     """
@@ -292,7 +256,6 @@ def test_table_names_after_from(completer, complete_event):
         complete_event))
     assert set(result) == set([
         Completion(text='public', start_position=0),
-        Completion(text='custom', start_position=0),
         Completion(text='users', start_position=0),
         Completion(text='orders', start_position=0),
         Completion(text='"select"', start_position=0),

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -1,129 +1,227 @@
 from pgcli.packages.sqlcompletion import suggest_type
 import pytest
 
-def test_select_suggests_cols_with_table_scope():
-    suggestion = suggest_type('SELECT  FROM tabl', 'SELECT ')
-    assert suggestion == ('columns-and-functions', ['tabl'])
+def assert_equals(suggestions, expected_suggestions):
+    """ Wrapper to convert dataframes to structs
+    """
+    for suggestion in suggestions:
+        if 'tables' in suggestion:
+            suggestion['tables'] = suggestion['tables'].to_dict('list')
+
+    assert sorted(suggestions) == sorted(expected_suggestions)
+
+
+
+def test_select_suggests_cols_with_visible_table_scope():
+    suggestions = suggest_type('SELECT  FROM tabl', 'SELECT ')
+    assert_equals(suggestions,
+            [{'type': 'column',
+              'tables': {'schema': [None],
+                         'table': ['tabl'],
+                         'alias': [None]}},
+             {'type': 'function'}])
+
+def test_select_suggests_cols_with_qualified_table_scope():
+    suggestions = suggest_type('SELECT  FROM sch.tabl', 'SELECT ')
+    assert_equals(suggestions,
+            [{'type': 'column',
+              'tables': {'schema': ['sch'],
+                         'table': ['tabl'],
+                         'alias': [None]}},
+             {'type': 'function'}])
 
 def test_where_suggests_columns_functions():
-    suggestion = suggest_type('SELECT * FROM tabl WHERE ',
+    suggestions = suggest_type('SELECT * FROM tabl WHERE ',
             'SELECT * FROM tabl WHERE ')
-    assert suggestion == ('columns-and-functions', ['tabl'])
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [None], 'table': ['tabl'], 'alias': [None]}},
+         {'type': 'function'}])
 
 def test_lparen_suggests_cols():
     suggestion = suggest_type('SELECT MAX( FROM tbl', 'SELECT MAX(')
-    assert suggestion == ('columns', ['tbl'])
+    assert_equals(suggestion,
+        [{'type': 'column',
+          'tables': {'schema': [None], 'table': ['tbl'], 'alias': [None]}}])
 
 def test_select_suggests_cols_and_funcs():
-    suggestion = suggest_type('SELECT ', 'SELECT ')
-    assert suggestion == ('columns-and-functions', [])
+    suggestions = suggest_type('SELECT ', 'SELECT ')
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [], 'table': [], 'alias': []}},
+         {'type': 'function'}])
 
-def test_from_suggests_tables():
+def test_from_suggests_tables_and_schemas():
     suggestion = suggest_type('SELECT * FROM ', 'SELECT * FROM ')
-    assert suggestion == ('tables', [])
+    assert sorted(suggestion) == sorted([
+        {'type': 'table', 'schema':[]},
+        {'type': 'schema'}])
 
 def test_distinct_suggests_cols():
-    suggestion = suggest_type('SELECT DISTINCT ', 'SELECT DISTINCT ')
-    assert suggestion == ('columns', [])
+    suggestions = suggest_type('SELECT DISTINCT ', 'SELECT DISTINCT ')
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [], 'table': [], 'alias': []}}])
 
 def test_col_comma_suggests_cols():
     suggestion = suggest_type('SELECT a, b, FROM tbl', 'SELECT a, b,')
-    assert suggestion == ('columns-and-functions', ['tbl'])
+    assert_equals(suggestion,
+        [{'type': 'column',
+          'tables': {'schema': [None],
+                     'table': ['tbl'],
+                     'alias': [None]}},
+         {'type': 'function'}])
 
-def test_table_comma_suggests_tables():
+def test_table_comma_suggests_tables_and_schemas():
     suggestion = suggest_type('SELECT a, b FROM tbl1, ',
             'SELECT a, b FROM tbl1, ')
-    assert suggestion == ('tables', [])
+    assert sorted(suggestion) == sorted([
+        {'type': 'table', 'schema':[]},
+        {'type': 'schema'}])
 
-def test_into_suggests_tables():
+def test_into_suggests_tables_and_schemas():
     suggestion = suggest_type('INSERT INTO ', 'INSERT INTO ')
-    assert suggestion == ('tables', [])
+    assert sorted(suggestion) == sorted([
+        {'type': 'table', 'schema': []},
+        {'type': 'schema'}])
 
 def test_insert_into_lparen_suggests_cols():
-    suggestion = suggest_type('INSERT INTO abc (', 'INSERT INTO abc (')
-    assert suggestion == ('columns', ['abc'])
+    suggestions = suggest_type('INSERT INTO abc (', 'INSERT INTO abc (')
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [None],
+                     'table': ['abc'],
+                     'alias': [None]}}])
 
 def test_insert_into_lparen_partial_text_suggests_cols():
-    suggestion = suggest_type('INSERT INTO abc (i', 'INSERT INTO abc (i')
-    assert suggestion == ('columns', ['abc'])
+    suggestions = suggest_type('INSERT INTO abc (i', 'INSERT INTO abc (i')
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [None],
+                     'table': ['abc'],
+                     'alias': [None]}}])
 
 def test_insert_into_lparen_comma_suggests_cols():
-    suggestion = suggest_type('INSERT INTO abc (id,', 'INSERT INTO abc (id,')
-    assert suggestion == ('columns', ['abc'])
+    suggestions = suggest_type('INSERT INTO abc (id,', 'INSERT INTO abc (id,')
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [None],
+                     'table': ['abc'],
+                     'alias': [None]}}])
 
 def test_partially_typed_col_name_suggests_col_names():
     suggestion = suggest_type('SELECT * FROM tabl WHERE col_n',
             'SELECT * FROM tabl WHERE col_n')
-    assert suggestion == ('columns-and-functions', ['tabl'])
+    assert_equals(suggestion,
+        [{'type': 'column',
+          'tables': {'schema': [None],
+                     'table': ['tabl'],
+                     'alias': [None]}},
+         {'type': 'function'}])
 
-def test_dot_suggests_cols_of_a_table():
-    suggestion = suggest_type('SELECT tabl. FROM tabl', 'SELECT tabl.')
-    assert suggestion == ('columns', ['tabl'])
+def test_dot_suggests_cols_of_a_table_or_schema_qualified_table():
+    suggestions = suggest_type('SELECT tabl. FROM tabl', 'SELECT tabl.')
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [None], 'table': ['tabl'], 'alias': [None]}},
+         {'type': 'table', 'schema': 'tabl'}])
+
+    suggestions = suggest_type('SELECT tabl. FROM tabl', 'SELECT tabl.')
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [None], 'table': ['tabl'], 'alias': [None]}},
+         {'type': 'table', 'schema': 'tabl'}])
 
 def test_dot_suggests_cols_of_an_alias():
-    suggestion = suggest_type('SELECT t1. FROM tabl1 t1, tabl2 t2',
+    suggestions = suggest_type('SELECT t1. FROM tabl1 t1, tabl2 t2',
             'SELECT t1.')
-    assert suggestion == ('columns', ['tabl1'])
+    assert_equals(suggestions,
+        [{'type': 'table', 'schema': 't1'},
+         {'type': 'column',
+          'tables': {'schema': [None], 'table': ['tabl1'], 'alias': ['t1']}}])
 
-def test_dot_col_comma_suggests_cols():
-    suggestion = suggest_type('SELECT t1.a, t2. FROM tabl1 t1, tabl2 t2',
+def test_dot_col_comma_suggests_cols_or_schema_qualified_table():
+    suggestions = suggest_type('SELECT t1.a, t2. FROM tabl1 t1, tabl2 t2',
             'SELECT t1.a, t2.')
-    assert suggestion == ('columns', ['tabl2'])
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [None],
+                     'table': ['tabl2'],
+                     'alias': ['t2']}},
+         {'type': 'table', 'schema': 't2'}])
 
 def test_sub_select_suggests_keyword():
     suggestion = suggest_type('SELECT * FROM (', 'SELECT * FROM (')
-    assert suggestion == ('keywords', [])
+    assert suggestion == [{'type': 'keyword'}]
 
 def test_sub_select_partial_text_suggests_keyword():
     suggestion = suggest_type('SELECT * FROM (S', 'SELECT * FROM (S')
-    assert suggestion == ('keywords', [])
+    assert suggestion == [{'type': 'keyword'}]
 
 def test_sub_select_table_name_completion():
     suggestion = suggest_type('SELECT * FROM (SELECT * FROM ',
             'SELECT * FROM (SELECT * FROM ')
-    assert suggestion == ('tables', [])
+    assert sorted(suggestion) == sorted([
+        {'type': 'table', 'schema': []}, {'type': 'schema'}])
 
 def test_sub_select_col_name_completion():
-    suggestion = suggest_type('SELECT * FROM (SELECT  FROM abc',
+    suggestions = suggest_type('SELECT * FROM (SELECT  FROM abc',
             'SELECT * FROM (SELECT ')
-    assert suggestion == ('columns-and-functions', ['abc'])
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [None], 'table': ['abc'], 'alias': [None]}},
+         {'type': 'function'}])
 
 @pytest.mark.xfail
 def test_sub_select_multiple_col_name_completion():
-    suggestion = suggest_type('SELECT * FROM (SELECT a, FROM abc',
+    suggestions = suggest_type('SELECT * FROM (SELECT a, FROM abc',
             'SELECT * FROM (SELECT a, ')
-    assert suggestion == ('columns-and-functions', ['abc'])
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [None], 'table': ['abc'], 'alias': [None]}},
+         {'type': 'function'}])
 
 def test_sub_select_dot_col_name_completion():
-    suggestion = suggest_type('SELECT * FROM (SELECT t. FROM tabl t',
+    suggestions = suggest_type('SELECT * FROM (SELECT t. FROM tabl t',
             'SELECT * FROM (SELECT t.')
-    assert suggestion == ('columns', ['tabl'])
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [None], 'table': ['tabl'], 'alias': ['t']}},
+         {'type': 'table', 'schema': 't'}])
 
-def test_join_suggests_tables():
+def test_join_suggests_tables_and_schemas():
     suggestion = suggest_type('SELECT * FROM abc a JOIN ',
             'SELECT * FROM abc a JOIN ')
-    assert suggestion == ('tables', [])
+    assert sorted(suggestion) == sorted([
+        {'type': 'table', 'schema': []},
+        {'type': 'schema'}])
 
 def test_join_alias_dot_suggests_cols1():
-    suggestion = suggest_type('SELECT * FROM abc a JOIN def d ON a.',
+    suggestions = suggest_type('SELECT * FROM abc a JOIN def d ON a.',
             'SELECT * FROM abc a JOIN def d ON a.')
-    assert suggestion == ('columns', ['abc'])
+    assert_equals(suggestions,
+        [{'type': 'column',
+          'tables': {'schema': [None], 'table': ['abc'], 'alias': ['a']}},
+         {'type': 'table', 'schema': 'a'}])
 
 def test_join_alias_dot_suggests_cols2():
     suggestion = suggest_type('SELECT * FROM abc a JOIN def d ON a.',
             'SELECT * FROM abc a JOIN def d ON a.id = d.')
-    assert suggestion == ('columns', ['def'])
+    assert_equals(suggestion,
+        [{'type': 'column',
+          'tables': {'schema': [None], 'table': ['def'], 'alias': ['d']}},
+         {'type': 'table', 'schema': 'd'}])
 
 def test_on_suggests_aliases():
-    category, scope = suggest_type(
+    suggestions = suggest_type(
         'select a.x, b.y from abc a join bcd b on ',
         'select a.x, b.y from abc a join bcd b on ')
-    assert category == 'tables-or-aliases'
-    assert set(scope) == set(['a', 'b'])
+    assert_equals(suggestions,
+        [{'type': 'alias', 'aliases': ['a', 'b']}])
 
 def test_on_suggests_tables():
-    category, scope = suggest_type(
+    suggestions = suggest_type(
         'select abc.x, bcd.y from abc join bcd on ',
         'select abc.x, bcd.y from abc join bcd on ')
-    assert category == 'tables-or-aliases'
-    assert set(scope) == set(['abc', 'bcd'])
+    assert_equals(suggestions,
+        [{'type': 'alias', 'aliases': ['abc', 'bcd']}])

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -1,22 +1,26 @@
 from pgcli.packages.sqlcompletion import suggest_type
 import pytest
 
+def sorted_dicts(dicts):
+    """input is a list of dicts"""
+    return sorted(tuple(x.items()) for x in dicts)
+
 def test_select_suggests_cols_with_visible_table_scope():
     suggestions = suggest_type('SELECT  FROM tabl', 'SELECT ')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
             {'type': 'column', 'tables': [(None, 'tabl', None)]},
             {'type': 'function'}])
 
 def test_select_suggests_cols_with_qualified_table_scope():
     suggestions = suggest_type('SELECT  FROM sch.tabl', 'SELECT ')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
             {'type': 'column', 'tables': [('sch', 'tabl', None)]},
             {'type': 'function'}])
 
 def test_where_suggests_columns_functions():
     suggestions = suggest_type('SELECT * FROM tabl WHERE ',
             'SELECT * FROM tabl WHERE ')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
             {'type': 'column', 'tables': [(None, 'tabl', None)]},
             {'type': 'function'}])
 
@@ -27,13 +31,13 @@ def test_lparen_suggests_cols():
 
 def test_select_suggests_cols_and_funcs():
     suggestions = suggest_type('SELECT ', 'SELECT ')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
          {'type': 'column', 'tables': []},
          {'type': 'function'}])
 
 def test_from_suggests_tables_and_schemas():
     suggestions = suggest_type('SELECT * FROM ', 'SELECT * FROM ')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'table', 'schema': []},
         {'type': 'schema'}])
 
@@ -43,20 +47,20 @@ def test_distinct_suggests_cols():
 
 def test_col_comma_suggests_cols():
     suggestions = suggest_type('SELECT a, b, FROM tbl', 'SELECT a, b,')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'column', 'tables': [(None, 'tbl', None)]},
          {'type': 'function'}])
 
 def test_table_comma_suggests_tables_and_schemas():
     suggestions = suggest_type('SELECT a, b FROM tbl1, ',
             'SELECT a, b FROM tbl1, ')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'table', 'schema': []},
         {'type': 'schema'}])
 
 def test_into_suggests_tables_and_schemas():
     suggestion = suggest_type('INSERT INTO ', 'INSERT INTO ')
-    assert sorted(suggestion) == sorted([
+    assert sorted_dicts(suggestion) == sorted_dicts([
         {'type': 'table', 'schema': []},
         {'type': 'schema'}])
 
@@ -75,27 +79,27 @@ def test_insert_into_lparen_comma_suggests_cols():
 def test_partially_typed_col_name_suggests_col_names():
     suggestions = suggest_type('SELECT * FROM tabl WHERE col_n',
             'SELECT * FROM tabl WHERE col_n')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'column', 'tables': [(None, 'tabl', None)]},
         {'type': 'function'}])
 
 def test_dot_suggests_cols_of_a_table_or_schema_qualified_table():
     suggestions = suggest_type('SELECT tabl. FROM tabl', 'SELECT tabl.')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'column', 'tables': [(None, 'tabl', None)]},
         {'type': 'table', 'schema': 'tabl'}])
 
 def test_dot_suggests_cols_of_an_alias():
     suggestions = suggest_type('SELECT t1. FROM tabl1 t1, tabl2 t2',
             'SELECT t1.')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'table', 'schema': 't1'},
         {'type': 'column', 'tables': [(None, 'tabl1', 't1')]}])
 
 def test_dot_col_comma_suggests_cols_or_schema_qualified_table():
     suggestions = suggest_type('SELECT t1.a, t2. FROM tabl1 t1, tabl2 t2',
             'SELECT t1.a, t2.')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'column', 'tables': [(None, 'tabl2', 't2')]},
         {'type': 'table', 'schema': 't2'}])
 
@@ -110,13 +114,13 @@ def test_sub_select_partial_text_suggests_keyword():
 def test_sub_select_table_name_completion():
     suggestion = suggest_type('SELECT * FROM (SELECT * FROM ',
             'SELECT * FROM (SELECT * FROM ')
-    assert sorted(suggestion) == sorted([
+    assert sorted_dicts(suggestion) == sorted_dicts([
         {'type': 'table', 'schema': []}, {'type': 'schema'}])
 
 def test_sub_select_col_name_completion():
     suggestions = suggest_type('SELECT * FROM (SELECT  FROM abc',
             'SELECT * FROM (SELECT ')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'column', 'tables': [(None, 'abc', None)]},
         {'type': 'function'}])
 
@@ -124,35 +128,35 @@ def test_sub_select_col_name_completion():
 def test_sub_select_multiple_col_name_completion():
     suggestions = suggest_type('SELECT * FROM (SELECT a, FROM abc',
             'SELECT * FROM (SELECT a, ')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'column', 'tables': [(None, 'abc', None)]},
         {'type': 'function'}])
 
 def test_sub_select_dot_col_name_completion():
     suggestions = suggest_type('SELECT * FROM (SELECT t. FROM tabl t',
             'SELECT * FROM (SELECT t.')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'column', 'tables': [(None, 'tabl', 't')]},
         {'type': 'table', 'schema': 't'}])
 
 def test_join_suggests_tables_and_schemas():
     suggestion = suggest_type('SELECT * FROM abc a JOIN ',
             'SELECT * FROM abc a JOIN ')
-    assert sorted(suggestion) == sorted([
+    assert sorted_dicts(suggestion) == sorted_dicts([
         {'type': 'table', 'schema': []},
         {'type': 'schema'}])
 
 def test_join_alias_dot_suggests_cols1():
     suggestions = suggest_type('SELECT * FROM abc a JOIN def d ON a.',
             'SELECT * FROM abc a JOIN def d ON a.')
-    assert sorted(suggestions) == sorted([
+    assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'column', 'tables': [(None, 'abc', 'a')]},
         {'type': 'table', 'schema': 'a'}])
 
 def test_join_alias_dot_suggests_cols2():
     suggestion = suggest_type('SELECT * FROM abc a JOIN def d ON a.',
             'SELECT * FROM abc a JOIN def d ON a.id = d.')
-    assert sorted(suggestion) == sorted([
+    assert sorted_dicts(suggestion) == sorted_dicts([
         {'type': 'column', 'tables': [(None, 'def', 'd')]},
         {'type': 'table', 'schema': 'd'}])
 

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -1,82 +1,57 @@
 from pgcli.packages.sqlcompletion import suggest_type
 import pytest
 
-def assert_equals(suggestions, expected_suggestions):
-    """ Wrapper to convert dataframes to structs
-    """
-    for suggestion in suggestions:
-        if 'tables' in suggestion:
-            suggestion['tables'] = suggestion['tables'].to_dict('list')
-
-    assert sorted(suggestions) == sorted(expected_suggestions)
-
-
-
 def test_select_suggests_cols_with_visible_table_scope():
     suggestions = suggest_type('SELECT  FROM tabl', 'SELECT ')
-    assert_equals(suggestions,
-            [{'type': 'column',
-              'tables': {'schema': [None],
-                         'table': ['tabl'],
-                         'alias': [None]}},
-             {'type': 'function'}])
+    assert sorted(suggestions) == sorted([
+            {'type': 'column', 'tables': [(None, 'tabl', None)]},
+            {'type': 'function'}])
 
 def test_select_suggests_cols_with_qualified_table_scope():
     suggestions = suggest_type('SELECT  FROM sch.tabl', 'SELECT ')
-    assert_equals(suggestions,
-            [{'type': 'column',
-              'tables': {'schema': ['sch'],
-                         'table': ['tabl'],
-                         'alias': [None]}},
-             {'type': 'function'}])
+    assert sorted(suggestions) == sorted([
+            {'type': 'column', 'tables': [('sch', 'tabl', None)]},
+            {'type': 'function'}])
 
 def test_where_suggests_columns_functions():
     suggestions = suggest_type('SELECT * FROM tabl WHERE ',
             'SELECT * FROM tabl WHERE ')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [None], 'table': ['tabl'], 'alias': [None]}},
-         {'type': 'function'}])
+    assert sorted(suggestions) == sorted([
+            {'type': 'column', 'tables': [(None, 'tabl', None)]},
+            {'type': 'function'}])
 
 def test_lparen_suggests_cols():
     suggestion = suggest_type('SELECT MAX( FROM tbl', 'SELECT MAX(')
-    assert_equals(suggestion,
-        [{'type': 'column',
-          'tables': {'schema': [None], 'table': ['tbl'], 'alias': [None]}}])
+    assert suggestion == [
+        {'type': 'column', 'tables': [(None, 'tbl', None)]}]
 
 def test_select_suggests_cols_and_funcs():
     suggestions = suggest_type('SELECT ', 'SELECT ')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [], 'table': [], 'alias': []}},
+    assert sorted(suggestions) == sorted([
+         {'type': 'column', 'tables': []},
          {'type': 'function'}])
 
 def test_from_suggests_tables_and_schemas():
-    suggestion = suggest_type('SELECT * FROM ', 'SELECT * FROM ')
-    assert sorted(suggestion) == sorted([
-        {'type': 'table', 'schema':[]},
+    suggestions = suggest_type('SELECT * FROM ', 'SELECT * FROM ')
+    assert sorted(suggestions) == sorted([
+        {'type': 'table', 'schema': []},
         {'type': 'schema'}])
 
 def test_distinct_suggests_cols():
     suggestions = suggest_type('SELECT DISTINCT ', 'SELECT DISTINCT ')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [], 'table': [], 'alias': []}}])
+    assert suggestions == [{'type': 'column', 'tables': []}]
 
 def test_col_comma_suggests_cols():
-    suggestion = suggest_type('SELECT a, b, FROM tbl', 'SELECT a, b,')
-    assert_equals(suggestion,
-        [{'type': 'column',
-          'tables': {'schema': [None],
-                     'table': ['tbl'],
-                     'alias': [None]}},
+    suggestions = suggest_type('SELECT a, b, FROM tbl', 'SELECT a, b,')
+    assert sorted(suggestions) == sorted([
+        {'type': 'column', 'tables': [(None, 'tbl', None)]},
          {'type': 'function'}])
 
 def test_table_comma_suggests_tables_and_schemas():
-    suggestion = suggest_type('SELECT a, b FROM tbl1, ',
+    suggestions = suggest_type('SELECT a, b FROM tbl1, ',
             'SELECT a, b FROM tbl1, ')
-    assert sorted(suggestion) == sorted([
-        {'type': 'table', 'schema':[]},
+    assert sorted(suggestions) == sorted([
+        {'type': 'table', 'schema': []},
         {'type': 'schema'}])
 
 def test_into_suggests_tables_and_schemas():
@@ -87,68 +62,42 @@ def test_into_suggests_tables_and_schemas():
 
 def test_insert_into_lparen_suggests_cols():
     suggestions = suggest_type('INSERT INTO abc (', 'INSERT INTO abc (')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [None],
-                     'table': ['abc'],
-                     'alias': [None]}}])
+    assert suggestions == [{'type': 'column', 'tables': [(None, 'abc', None)]}]
 
 def test_insert_into_lparen_partial_text_suggests_cols():
     suggestions = suggest_type('INSERT INTO abc (i', 'INSERT INTO abc (i')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [None],
-                     'table': ['abc'],
-                     'alias': [None]}}])
+    assert suggestions == [{'type': 'column', 'tables': [(None, 'abc', None)]}]
 
 def test_insert_into_lparen_comma_suggests_cols():
     suggestions = suggest_type('INSERT INTO abc (id,', 'INSERT INTO abc (id,')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [None],
-                     'table': ['abc'],
-                     'alias': [None]}}])
+    assert suggestions == [{'type': 'column', 'tables': [(None, 'abc', None)]}]
 
 def test_partially_typed_col_name_suggests_col_names():
-    suggestion = suggest_type('SELECT * FROM tabl WHERE col_n',
+    suggestions = suggest_type('SELECT * FROM tabl WHERE col_n',
             'SELECT * FROM tabl WHERE col_n')
-    assert_equals(suggestion,
-        [{'type': 'column',
-          'tables': {'schema': [None],
-                     'table': ['tabl'],
-                     'alias': [None]}},
-         {'type': 'function'}])
+    assert sorted(suggestions) == sorted([
+        {'type': 'column', 'tables': [(None, 'tabl', None)]},
+        {'type': 'function'}])
 
 def test_dot_suggests_cols_of_a_table_or_schema_qualified_table():
     suggestions = suggest_type('SELECT tabl. FROM tabl', 'SELECT tabl.')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [None], 'table': ['tabl'], 'alias': [None]}},
-         {'type': 'table', 'schema': 'tabl'}])
-
-    suggestions = suggest_type('SELECT tabl. FROM tabl', 'SELECT tabl.')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [None], 'table': ['tabl'], 'alias': [None]}},
-         {'type': 'table', 'schema': 'tabl'}])
+    assert sorted(suggestions) == sorted([
+        {'type': 'column', 'tables': [(None, 'tabl', None)]},
+        {'type': 'table', 'schema': 'tabl'}])
 
 def test_dot_suggests_cols_of_an_alias():
     suggestions = suggest_type('SELECT t1. FROM tabl1 t1, tabl2 t2',
             'SELECT t1.')
-    assert_equals(suggestions,
-        [{'type': 'table', 'schema': 't1'},
-         {'type': 'column',
-          'tables': {'schema': [None], 'table': ['tabl1'], 'alias': ['t1']}}])
+    assert sorted(suggestions) == sorted([
+        {'type': 'table', 'schema': 't1'},
+        {'type': 'column', 'tables': [(None, 'tabl1', 't1')]}])
 
 def test_dot_col_comma_suggests_cols_or_schema_qualified_table():
     suggestions = suggest_type('SELECT t1.a, t2. FROM tabl1 t1, tabl2 t2',
             'SELECT t1.a, t2.')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [None],
-                     'table': ['tabl2'],
-                     'alias': ['t2']}},
-         {'type': 'table', 'schema': 't2'}])
+    assert sorted(suggestions) == sorted([
+        {'type': 'column', 'tables': [(None, 'tabl2', 't2')]},
+        {'type': 'table', 'schema': 't2'}])
 
 def test_sub_select_suggests_keyword():
     suggestion = suggest_type('SELECT * FROM (', 'SELECT * FROM (')
@@ -167,27 +116,24 @@ def test_sub_select_table_name_completion():
 def test_sub_select_col_name_completion():
     suggestions = suggest_type('SELECT * FROM (SELECT  FROM abc',
             'SELECT * FROM (SELECT ')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [None], 'table': ['abc'], 'alias': [None]}},
-         {'type': 'function'}])
+    assert sorted(suggestions) == sorted([
+        {'type': 'column', 'tables': [(None, 'abc', None)]},
+        {'type': 'function'}])
 
 @pytest.mark.xfail
 def test_sub_select_multiple_col_name_completion():
     suggestions = suggest_type('SELECT * FROM (SELECT a, FROM abc',
             'SELECT * FROM (SELECT a, ')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [None], 'table': ['abc'], 'alias': [None]}},
-         {'type': 'function'}])
+    assert sorted(suggestions) == sorted([
+        {'type': 'column', 'tables': [(None, 'abc', None)]},
+        {'type': 'function'}])
 
 def test_sub_select_dot_col_name_completion():
     suggestions = suggest_type('SELECT * FROM (SELECT t. FROM tabl t',
             'SELECT * FROM (SELECT t.')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [None], 'table': ['tabl'], 'alias': ['t']}},
-         {'type': 'table', 'schema': 't'}])
+    assert sorted(suggestions) == sorted([
+        {'type': 'column', 'tables': [(None, 'tabl', 't')]},
+        {'type': 'table', 'schema': 't'}])
 
 def test_join_suggests_tables_and_schemas():
     suggestion = suggest_type('SELECT * FROM abc a JOIN ',
@@ -199,43 +145,37 @@ def test_join_suggests_tables_and_schemas():
 def test_join_alias_dot_suggests_cols1():
     suggestions = suggest_type('SELECT * FROM abc a JOIN def d ON a.',
             'SELECT * FROM abc a JOIN def d ON a.')
-    assert_equals(suggestions,
-        [{'type': 'column',
-          'tables': {'schema': [None], 'table': ['abc'], 'alias': ['a']}},
-         {'type': 'table', 'schema': 'a'}])
+    assert sorted(suggestions) == sorted([
+        {'type': 'column', 'tables': [(None, 'abc', 'a')]},
+        {'type': 'table', 'schema': 'a'}])
 
 def test_join_alias_dot_suggests_cols2():
     suggestion = suggest_type('SELECT * FROM abc a JOIN def d ON a.',
             'SELECT * FROM abc a JOIN def d ON a.id = d.')
-    assert_equals(suggestion,
-        [{'type': 'column',
-          'tables': {'schema': [None], 'table': ['def'], 'alias': ['d']}},
-         {'type': 'table', 'schema': 'd'}])
+    assert sorted(suggestion) == sorted([
+        {'type': 'column', 'tables': [(None, 'def', 'd')]},
+        {'type': 'table', 'schema': 'd'}])
 
 def test_on_suggests_aliases():
     suggestions = suggest_type(
         'select a.x, b.y from abc a join bcd b on ',
         'select a.x, b.y from abc a join bcd b on ')
-    assert_equals(suggestions,
-        [{'type': 'alias', 'aliases': ['a', 'b']}])
+    assert suggestions == [{'type': 'alias', 'aliases': ['a', 'b']}]
 
 def test_on_suggests_tables():
     suggestions = suggest_type(
         'select abc.x, bcd.y from abc join bcd on ',
         'select abc.x, bcd.y from abc join bcd on ')
-    assert_equals(suggestions,
-        [{'type': 'alias', 'aliases': ['abc', 'bcd']}])
+    assert suggestions == [{'type': 'alias', 'aliases': ['abc', 'bcd']}]
     
 def test_on_suggests_aliases_right_side():
     suggestions = suggest_type(
         'select a.x, b.y from abc a join bcd b on a.id = ',
         'select a.x, b.y from abc a join bcd b on a.id = ')
-    assert_equals(suggestions,
-        [{'type': 'alias', 'aliases': ['a', 'b']}])
+    assert suggestions == [{'type': 'alias', 'aliases': ['a', 'b']}]
         
 def test_on_suggests_tables_right_side():
     suggestions = suggest_type(
         'select abc.x, bcd.y from abc join bcd on ',
         'select abc.x, bcd.y from abc join bcd on ')
-    assert_equals(suggestions,
-        [{'type': 'alias', 'aliases': ['abc', 'bcd']}])
+    assert suggestions == [{'type': 'alias', 'aliases': ['abc', 'bcd']}]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,7 +32,11 @@ def create_db(dbname):
 
 def drop_tables(conn):
     with conn.cursor() as cur:
-        cur.execute('''DROP SCHEMA public CASCADE; CREATE SCHEMA public''')
+        cur.execute('''
+            DROP SCHEMA public CASCADE;
+            CREATE SCHEMA public;
+            DROP SCHEMA IF EXISTS schema1 CASCADE;
+            DROP SCHEMA IF EXISTS schema2 CASCADE''')
 
 
 def run(executor, sql, join=False):


### PR DESCRIPTION
This PR would fix #22, and also I think #39 as a side-effect

Issues:
  * I used pandas DataFrames for working with database metadata -- I found them a lot more flexible than a pure standard lib dict/list based approach. But I'm not sure how you'd feel about adding pandas as a requirement.
  * We don't have any tests for "DoubleQuoted" identifiers -- I'm not confident I didn't break that.

