### PR TITLE
Cast bytea fields to text for output.

### DIFF
--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -13,6 +13,11 @@ _logger = logging.getLogger(__name__)
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)
 
+# Cast bytea fields to text. By default, this will render as hex strings with
+# Postgres 9+ and as escaped binary in earlier versions.
+psycopg2.extensions.register_type(
+    psycopg2.extensions.new_type((17,), 'BYTEA_TEXT', psycopg2.STRING))
+
 # When running a query, make pressing CTRL+C raise a KeyboardInterrupt
 # See http://initd.org/psycopg/articles/2014/07/20/cancelling-postgresql-statements-python/
 psycopg2.extensions.set_wait_callback(psycopg2.extras.wait_select)

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -113,3 +113,12 @@ def test_multiple_queries_same_line_syntaxerror(executor):
 @dbtest
 def test_special_command(executor):
     run(executor, '\\?')
+
+
+@dbtest
+def test_bytea_field_support_in_output(executor):
+    run(executor, "create table binarydata(c bytea)")
+    run(executor,
+        "insert into binarydata (c) values (decode('DEADBEEF', 'hex'))")
+
+    assert u'\\xdeadbeef' in run(executor, "select * from binarydata", join=True)


### PR DESCRIPTION
In the current version of pgcli, `bytea` fields trigger Unicode decode errors when queried:

    _test_db> CREATE TABLE binarydata(c bytea) 
    CREATE TABLE
    _test_db> INSERT INTO binarydata VALUES (decode('DEADBEEF', 'hex'))
    INSERT 0 1
    _test_db> SELECT * FROM binarydata
    'ascii' codec can't decode byte 0xde in position 0: ordinal not in range(128)
    _test_db> 

Casting the field to a string for display allows tables with `bytea` fields to be queried as expected. This pull request adds a type converter to have psycopg2 automatically perform the conversion on all `bytea` fields:

    _test_db> SELECT * FROM binarydata
    +------------+
    | c          |
    |------------|
    | \xdeadbeef |
    +------------+
    SELECT 1
    _test_db> 
