### PR TITLE
bugfix: make tables query schema filter match schematas query

### DIFF
--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -96,7 +96,11 @@ class PGCompleter(Completer):
         # dbmetadata['schema_name']['table_name'] should be a list of column
         # names. Default to an asterisk
         for schema, table in table_data:
-            self.dbmetadata[schema][table] = ['*']
+            try:
+                self.dbmetadata[schema][table] = ['*']
+            except AttributeError:
+                _logger.error('Table %r listed in unrecognized schema %r',
+                              table, schema)
 
         self.all_completions.update(t[1] for t in table_data)
 

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -43,8 +43,8 @@ class PGExecute(object):
                 LEFT JOIN pg_catalog.pg_namespace n
                     ON n.oid = c.relnamespace
         WHERE 	c.relkind IN ('r','v', 'm') -- table, view, materialized view
-                AND n.nspname !~ '^pg_toast'
-                AND n.nspname NOT IN ('information_schema', 'pg_catalog')
+                AND n.nspname !~ '^pg_'
+                AND nspname <> 'information_schema'
         ORDER BY 1,2;'''
 
     columns_query = '''


### PR DESCRIPTION
pgcli crashed for me today after making a new schema:

```
 File "C:\Users\dg\Anaconda3\envs\pgcli2\Scripts\pgcli-script.py", line 9, in <module>
    load_entry_point('pgcli==0.15.2', 'console_scripts', 'pgcli')()
  File "C:\Users\dg\Anaconda3\envs\pgcli2\lib\site-packages\click\core.py", line 610, in __call__
    return self.main(*args, **kwargs)
  File "C:\Users\dg\Anaconda3\envs\pgcli2\lib\site-packages\click\core.py", line 590, in main
    rv = self.invoke(ctx)
  File "C:\Users\dg\Anaconda3\envs\pgcli2\lib\site-packages\click\core.py", line 782, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\dg\Anaconda3\envs\pgcli2\lib\site-packages\click\core.py", line 416, in invoke
    return callback(*args, **kwargs)
  File "c:\users\dg\documents\python\pgcli\pgcli\main.py", line 331, in cli
    pgcli.run_cli()
  File "c:\users\dg\documents\python\pgcli\pgcli\main.py", line 250, in run_cli
    self.refresh_completions()
  File "c:\users\dg\documents\python\pgcli\pgcli\main.py", line 287, in refresh_completions
    completer.extend_tables(pgexecute.tables())
  File "c:\users\dg\documents\python\pgcli\pgcli\pgcompleter.py", line 106, in extend_tables
    self.dbmetadata['tables'][schema][table] = ['*']
KeyError: u'pg_temp_4'
```

This was my mistake from the schema PR