### PR TITLE
Some small \special improvements

### DIFF
--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -103,6 +103,11 @@ def suggest_special(text):
             return [{'type': 'table', 'schema': schema}]
         else:
             return [{'type': 'schema'}, {'type': 'table', 'schema': []}]
+    elif cmd[1:] == 'df':
+        if schema:
+            return [{'type': 'function', 'schema': schema}]
+        else:
+            return [{'type': 'schema'}, {'type': 'function', 'schema': []}]
 
     return [{'type': 'keyword'}, {'type': 'special'}]
 

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -86,6 +86,9 @@ def suggest_special(text):
     if cmd == '\\c':
         return [{'type': 'database'}]
 
+    if cmd == '\\dn':
+        return [{'type': 'schema'}]
+
     if arg:
         # Try to distinguish "\d name" from "\d schema.name"
         # Note that this will fail to obtain a schema name if wildcards are

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -77,6 +77,7 @@ def suggest_type(full_text, text_before_cursor):
 
 
 def suggest_special(text):
+    text = text.lstrip()
     cmd, _, arg = parse_special_command(text)
 
     if cmd == text:

--- a/tests/test_pgspecial.py
+++ b/tests/test_pgspecial.py
@@ -11,6 +11,14 @@ def test_slash_d_suggests_special():
     assert sorted_dicts(suggestions) == sorted_dicts(
         [{'type': 'special'}])
 
+def test_dn_suggests_schemata():
+    suggestions = suggest_type('\\dn ', '\\dn ')
+    assert suggestions == [{'type': 'schema'}]
+
+    suggestions = suggest_type('\\dn xxx', '\\dn xxx')
+    assert suggestions == [{'type': 'schema'}]
+
+
 def test_d_suggests_tables_and_schemas():
     suggestions = suggest_type('\d ', '\d ')
     assert sorted_dicts(suggestions) == sorted_dicts([

--- a/tests/test_pgspecial.py
+++ b/tests/test_pgspecial.py
@@ -1,6 +1,16 @@
 from pgcli.packages.sqlcompletion import suggest_type
 from test_sqlcompletion import sorted_dicts
 
+def test_slash_suggests_special():
+    suggestions = suggest_type('\\', '\\')
+    assert sorted_dicts(suggestions) == sorted_dicts(
+        [{'type': 'special'}])
+
+def test_slash_d_suggests_special():
+    suggestions = suggest_type('\\d', '\\d')
+    assert sorted_dicts(suggestions) == sorted_dicts(
+        [{'type': 'special'}])
+
 def test_d_suggests_tables_and_schemas():
     suggestions = suggest_type('\d ', '\d ')
     assert sorted_dicts(suggestions) == sorted_dicts([

--- a/tests/test_pgspecial.py
+++ b/tests/test_pgspecial.py
@@ -18,7 +18,6 @@ def test_dn_suggests_schemata():
     suggestions = suggest_type('\\dn xxx', '\\dn xxx')
     assert suggestions == [{'type': 'schema'}]
 
-
 def test_d_suggests_tables_and_schemas():
     suggestions = suggest_type('\d ', '\d ')
     assert sorted_dicts(suggestions) == sorted_dicts([
@@ -42,3 +41,9 @@ def test_df_suggests_schema_or_function():
 
     suggestions = suggest_type('\\df myschema.xxx', '\\df myschema.xxx')
     assert suggestions == [{'type': 'function', 'schema': 'myschema'}]
+
+def test_leading_whitespace_ok():
+    cmd = '\\dn '
+    whitespace = '   '
+    suggestions = suggest_type(whitespace + cmd, whitespace + cmd)
+    assert suggestions == suggest_type(cmd, cmd)

--- a/tests/test_pgspecial.py
+++ b/tests/test_pgspecial.py
@@ -27,3 +27,10 @@ def test_d_dot_suggests_schema_qualified_tables():
     suggestions = suggest_type('\d myschema.xxx', '\d myschema.xxx')
     assert suggestions == [{'type': 'table', 'schema': 'myschema'}]
 
+def test_df_suggests_schema_or_function():
+    suggestions = suggest_type('\\df xxx', '\\df xxx')
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'function', 'schema': []}, {'type': 'schema'}])
+
+    suggestions = suggest_type('\\df myschema.xxx', '\\df myschema.xxx')
+    assert suggestions == [{'type': 'function', 'schema': 'myschema'}]


### PR DESCRIPTION
  -  Move special-related suggestions out of `suggest_based_on_last_token` and into a new `suggest_special` method
    - Special commands don't really obey sql syntax so this makes it easier to work around sqlparse
    - Have \d, \dt, and \dv suggest schema and table names
  - Add support for \df 
      - \df suggests schema and function names
  - \dn suggests schema names