### PR TITLE
Better handle schema qualifications in current word

### DIFF
--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -7,7 +7,7 @@ from sqlparse.tokens import Keyword, DML, Punctuation
 cleanup_regex = {
         # This matches only alphanumerics and underscores.
         'alphanum_underscore': re.compile(r'(\w+)$'),
-        # This matches everything except spaces, parens and comma.
+        # This matches everything except spaces, parens, comma, and period
         'most_punctuations': re.compile(r'([^\.(),\s]+)$'),
         # This matches everything except a space.
         'all_punctuations': re.compile('([^\s]+)$'),

--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -7,6 +7,8 @@ from sqlparse.tokens import Keyword, DML, Punctuation
 cleanup_regex = {
         # This matches only alphanumerics and underscores.
         'alphanum_underscore': re.compile(r'(\w+)$'),
+        # This matches everything except spaces, parens, and comma
+        'many_punctuations': re.compile(r'([^(),\s]+)$'),
         # This matches everything except spaces, parens, comma, and period
         'most_punctuations': re.compile(r'([^\.(),\s]+)$'),
         # This matches everything except a space.

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -145,9 +145,7 @@ def test_suggested_table_names_with_schema_dot(completer, complete_event):
     assert set(result) == set([
         Completion(text='users', start_position=0),
         Completion(text='products', start_position=0),
-        Completion(text='shipments', start_position=0),
-        Completion(text='func3', start_position=0),
-        Completion(text='func4', start_position=0)])
+        Completion(text='shipments', start_position=0)])
 
 def test_suggested_column_names_with_qualified_alias(completer, complete_event):
     """

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -253,3 +253,9 @@ def test_specials_not_included_after_initial_token():
                                'create table foo (dt d')
 
     assert sorted_dicts(suggestions) == sorted_dicts([{'type': 'keyword'}])
+
+
+def test_drop_schema_qualified_table_suggests_only_tables():
+    text = 'DROP TABLE schema_name.table_name'
+    suggestions = suggest_type(text, text)
+    assert suggestions == [{'type': 'table', 'schema': 'schema_name'}]


### PR DESCRIPTION
short version: fixes a bug where `DROP TABLE schema_name.<TAB>` and `DROP FUNCTION schema_name.<TAB>` would both suggest both tables and functions from schema_name.

Previously, if the current word contained a period, `suggest_type` would parse text to the right of the period as `word_before_cursor`, so that characters to the left of the period were parsed as the final token. Then `suggest_based_on_last_token` would generate suggestions under the generic catch-all `elif token_v.endswith('.')`. This means that, for example, `DROP TABLE schema_name.<TAB>` and `DROP FUNCTION schema_name.<TAB>` would each suggest both tables and functions from schema_name.

This commit PR changes this behavior to include schema qualifications as part of word_before_cursor, so that `suggest_based_on_last_token` operates on the actual preceding token, not just the schema name. The schema name itself is parsed as an sqlparse Identifier, and passed as an extra argument to suggest_based_on_last_token. This allows each token value to handle dot-qualifications differently, and may eventually support things like function output arguments `func().fieldname` or custom types with `arbitrarily.deep.nested.child.fields`