### PR TITLE
Format Decimal values directly as strings

### DIFF
--- a/pgcli/packages/tabulate.py
+++ b/pgcli/packages/tabulate.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 from collections import namedtuple
+from decimal import Decimal
 from platform import python_version_tuple
 import re
 
@@ -331,7 +332,7 @@ def _type(string, has_invisible=True):
 
     if string is None:
         return _none_type
-    if isinstance(string, bool):
+    if isinstance(string, (bool, Decimal,)):
         return _text_type
     elif hasattr(string, "isoformat"):  # datetime.datetime, date, and time
         return _text_type

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -147,3 +147,13 @@ def test_jsonb_renders_without_u_prefix(executor, expanded):
     result = run(executor, "SELECT d FROM jsonbtest LIMIT 1", join=True)
 
     assert u'{"name": "Éowyn"}' in result
+
+
+@dbtest
+@pytest.mark.parametrize('value', ['10000000', '10000000.0', '10000000000000'])
+def test_large_numbers_render_directly(executor, value):
+    run(executor, "create table numbertest(a numeric)")
+    run(executor,
+        "insert into numbertest (a) values ({0})".format(value))
+
+    assert value in run(executor, "select * from numbertest", join=True)


### PR DESCRIPTION
The failure listed in the issue is rooted in how tabulate handles Decimal objects, which, at bottom, end up being rendered via

    >>> format(float(Decimal(10000000)), 'g')
    '1e+07'

The 'g' format specifier is parameterized in tabulate, but changing it to '' only fixes some of the cases.

Next, I tried asking psycopg2 to return these values as strings rather than Decimal objects, but this also fails due to tabulate's aggressive coercion logic, which ends up giving you

    >>> format(float('10000000'), 'g')
    '1e+07'

The best solution is to render Decimal values directly as strings, which will correctly handle the difference between 10000000 and 10000000.0. Here is an example in pgcli

    postgres> SELECT * FROM numeric_test ORDER BY a
    +---------------+
    | a             |
    |---------------|
    | 1.0           |
    | 1.01          |
    | 10.0          |
    | 100           |
    | 10000000      |
    | 10000000.0    |
    | 1000000000000 |
    +---------------+
    SELECT 7
    Command Time: 9.05990600586e-06
    Format Time: 0.00118017196655
    postgres> 

 and the same query in psql
    
    postgres=# select * from numeric_test order by a;
           a       
    ---------------
               1.0
              1.01
              10.0
               100
          10000000
        10000000.0
     1000000000000
    (7 rows)
    
    postgres=# 

I would normally avoid patching a vendored library like this, but this seems like the cleanest solution under the circumstances and matches previous fixes to a few other types.

Closes #169 