### PR TITLE
Fix typo

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -268,7 +268,7 @@ class PGCli(object):
                 self.query_history.append(query)
 
         except Exit:
-            print ('GoodBye!')
+            print ('Goodbye!')
         finally:  # Reset the less opts back to original.
             logger.debug('Restoring env var LESS to %r.', original_less_opts)
             os.environ['LESS'] = original_less_opts


### PR DESCRIPTION
A minor nitpick: since "goodbye" is one word, "bye" shouldn't be capitalized.
But otherwise, this is a huge improvement over `psql`!