### PR TITLE
Fix the checking to commands '\c' or 'use'

### DIFF
--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -178,7 +178,7 @@ class PGExecute(object):
             # exception that cannot be offloaded to `pgspecial` lib. Because we
             # have to change the database connection that we're connected to.
             command = sql.split()[0]
-            if command == '\c' or command.lower() == 'use':
+            if command == '\c' or command == '\connect' or command.lower() == 'use':
                 _logger.debug('Database change command detected.')
                 try:
                     dbname = sql.split()[1]

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -177,7 +177,8 @@ class PGExecute(object):
             # Check if the command is a \c or 'use'. This is a special
             # exception that cannot be offloaded to `pgspecial` lib. Because we
             # have to change the database connection that we're connected to.
-            if sql.startswith('\c') or sql.lower().startswith('use'):
+            command = sql.split()[0]
+            if command == '\c' or command.lower() == 'use':
                 _logger.debug('Database change command detected.')
                 try:
                     dbname = sql.split()[1]


### PR DESCRIPTION
I want to add a easter egg for my friend -- command `\cf` -- her name abbreviation,
but when I type `\cf`, it raises `Database name missing.`,
so I have fixed it.

I think it might be useful in the future.