### PR TITLE
Improve handling of pg_catalog in metadata

### DIFF
--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -201,18 +201,37 @@ class PGCompleter(Completer):
 
             elif suggestion['type'] == 'schema':
                 schema_names = self.dbmetadata['tables'].keys()
+
+                # Unless we're sure the user really wants them, hide schema
+                # names starting with pg_, which are mostly temporary schemas
+                if not word_before_cursor.startswith('pg_'):
+                    schema_names = [s for s in schema_names
+                                      if not s.startswith('pg_')]
+
                 schema_names = self.find_matches(word_before_cursor, schema_names)
                 completions.extend(schema_names)
 
             elif suggestion['type'] == 'table':
                 tables = self.populate_schema_objects(
                     suggestion['schema'], 'tables')
+
+                # Unless we're sure the user really wants them, don't suggest
+                # the pg_catalog tables that are implicitly on the search path
+                if not suggestion['schema'] and (
+                        not word_before_cursor.startswith('pg_')):
+                    tables = [t for t in tables if not t.startswith('pg_')]
+
                 tables = self.find_matches(word_before_cursor, tables)
                 completions.extend(tables)
 
             elif suggestion['type'] == 'view':
                 views = self.populate_schema_objects(
                     suggestion['schema'], 'views')
+
+                if not suggestion['schema'] and (
+                        not word_before_cursor.startswith('pg_')):
+                    views = [v for v in views if not v.startswith('pg_')]
+
                 views = self.find_matches(word_before_cursor, views)
                 completions.extend(views)
 

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -72,8 +72,6 @@ class PGExecute(object):
     schemata_query = '''
         SELECT  nspname
         FROM    pg_catalog.pg_namespace
-        WHERE   nspname !~ '^pg_'
-                AND nspname <> 'information_schema'
         ORDER BY 1 '''
 
     tables_query = '''
@@ -83,8 +81,6 @@ class PGExecute(object):
                 LEFT JOIN pg_catalog.pg_namespace n
                     ON n.oid = c.relnamespace
         WHERE 	c.relkind = ANY(%s)
-                AND n.nspname !~ '^pg_'
-                AND nspname <> 'information_schema'
         ORDER BY 1,2;'''
 
     columns_query = '''
@@ -97,8 +93,6 @@ class PGExecute(object):
                 INNER JOIN pg_catalog.pg_namespace nsp
                     ON cls.relnamespace = nsp.oid
         WHERE 	cls.relkind = ANY(%s)
-                AND nsp.nspname !~ '^pg_'
-                AND nsp.nspname <> 'information_schema'
                 AND NOT att.attisdropped
                 AND att.attnum  > 0
         ORDER BY 1, 2, 3'''

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -66,8 +66,10 @@ def register_hstore_typecaster(conn):
 
 class PGExecute(object):
 
+    # The boolean argument to the current_schemas function indicates whether
+    # implicit schemas, e.g. pg_catalog
     search_path_query = '''
-        SELECT * FROM unnest(current_schemas(false))'''
+        SELECT * FROM unnest(current_schemas(true))'''
 
     schemata_query = '''
         SELECT  nspname

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -39,23 +39,26 @@ def test_schemata_table_views_and_columns_query(executor):
     run(executor, "create schema schema2")
 
     # schemata
-    assert executor.schemata() == ['public', 'schema1', 'schema2']
-    assert executor.search_path() == ['public']
+    # don't enforce all members of the schemas since they may include postgres
+    # temporary schemas
+    assert set(executor.schemata()) >= set([
+        'public', 'pg_catalog', 'information_schema', 'schema1', 'schema2'])
+    assert executor.search_path() == ['pg_catalog', 'public']
 
     # tables
-    assert list(executor.tables()) == [
-        ('public', 'a'), ('public', 'b'), ('schema1', 'c')]
+    assert set(executor.tables()) >= set([
+        ('public', 'a'), ('public', 'b'), ('schema1', 'c')])
 
-    assert list(executor.table_columns()) == [
+    assert set(executor.table_columns()) >= set([
         ('public', 'a', 'x'), ('public', 'a', 'y'),
-        ('public', 'b', 'z'), ('schema1', 'c', 'w')]
+        ('public', 'b', 'z'), ('schema1', 'c', 'w')])
 
     # views
-    assert list(executor.views()) == [
-        ('public', 'd')]
+    assert set(executor.views()) >= set([
+        ('public', 'd')])
 
-    assert list(executor.view_columns()) == [
-        ('public', 'd', 'e')]
+    assert set(executor.view_columns()) >= set([
+        ('public', 'd', 'e')])
 
 @dbtest
 def test_functions_query(executor):


### PR DESCRIPTION
Originally, tables and schemas starting with `pg_`, as well as `information_schema` were not stored, under the assumption they would generate too many superfluous suggestions. This broke as soon as someone tried to manually add pg_catalog to the search path. #192 

Now, metadata is stored for all tables and schemas, and pg_catalog is correctly reported as being on the search_path, even though it is so implicitly. In order to prevent extraneous suggestions from `pg_catalog`, suggestions starting with `pg_` are suppressed, unless the user has already typed `pg_`, which seems like a reasonable compromise to me. 