### PR TITLE
Handle a ',' entered before any completions gracefully

### DIFF
--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -189,7 +189,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
     elif token_v.lower() in ('table', 'view', 'function'):
         # E.g. 'DROP FUNCTION <funcname>', 'ALTER TABLE <tablname>'
         rel_type = token_v.lower()
-        schema = (identifier and identifier.get_parent_name()) or []        
+        schema = (identifier and identifier.get_parent_name()) or []
         if schema:
             return [{'type': rel_type, 'schema': schema}]
         else:
@@ -220,6 +220,8 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         if prev_keyword:
             return suggest_based_on_last_token(
                 prev_keyword, text_before_cursor, full_text, identifier)
+        else:
+            return []
     else:
         return [{'type': 'keyword'}]
 

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -279,3 +279,10 @@ def test_drop_schema_qualified_table_suggests_only_tables():
     text = 'DROP TABLE schema_name.table_name'
     suggestions = suggest_type(text, text)
     assert suggestions == [{'type': 'table', 'schema': 'schema_name'}]
+
+
+@pytest.mark.parametrize('text', [',', '  ,', 'sel ,'])
+def test_handle_pre_completion_comma_gracefully(text):
+    suggestions = suggest_type(text, text)
+
+    assert iter(suggestions)


### PR DESCRIPTION
Fixes #197