### PR TITLE
Register the json handler only for PY2.

### DIFF
--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -141,8 +141,7 @@ class PGExecute(object):
             self.conn.close()
         self.conn = conn
         self.conn.autocommit = True
-        if PY2:
-            register_json_typecasters(self.conn, self._json_typecaster)
+        register_json_typecasters(self.conn, self._json_typecaster)
         register_hstore_typecaster(self.conn)
 
     def _json_typecaster(self, json_data):
@@ -154,7 +153,10 @@ class PGExecute(object):
         See http://initd.org/psycopg/docs/connection.html#connection.encoding
         """
 
-        return json_data.decode(self.conn.encoding)
+        if PY2:
+            return json_data.decode(self.conn.encoding)
+        else:
+            return json_data
 
     def run(self, statement):
         """Execute the sql in the database and return the results. The results

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -4,7 +4,7 @@ import psycopg2.extras
 import psycopg2.extensions as ext
 import sqlparse
 from .packages import pgspecial
-from .encodingutils import unicode2utf8
+from .encodingutils import unicode2utf8, PY2, PY3
 
 _logger = logging.getLogger(__name__)
 
@@ -141,7 +141,8 @@ class PGExecute(object):
             self.conn.close()
         self.conn = conn
         self.conn.autocommit = True
-        register_json_typecasters(self.conn, self._json_typecaster)
+        if PY2:
+            register_json_typecasters(self.conn, self._json_typecaster)
         register_hstore_typecaster(self.conn)
 
     def _json_typecaster(self, json_data):


### PR DESCRIPTION
Closes #201. 

@drocco007 Can you please verify this PR? 

The json handler is trying to decode the incoming string into unicode based on the database encoding. But this is only required if we're in Python 2, because in Python 3 psycopg2 already converts the string to unicode. But I want to double check my understanding.

The test case shown in #201 clearly highlights the problem. 

```
pgcli>  select '{"foo":42}'::json;
```